### PR TITLE
fix: show correct charging changes in info screen

### DIFF
--- a/components/display/src/DisplaySmBase.cpp
+++ b/components/display/src/DisplaySmBase.cpp
@@ -108,6 +108,7 @@ void DisplayBase::showErrorScreen() {
 
 void DisplayBase::showChargingScreen() {
     ESP_LOGI(TAG, "showChargingScreen");
+    charging = true;
     if (display_) {
         // TODO finalize screen
         display_->showIconScreen(UI_ICON_CHARGING, "Charging", " ");
@@ -116,6 +117,7 @@ void DisplayBase::showChargingScreen() {
 
 void DisplayBase::showChargingOffScreen() {
     ESP_LOGI(TAG, "showChargingOffScreen");
+    charging = false;
     if (display_) {
         // TODO finalize screen
         display_->showIconScreen(UI_ICON_NOT_CHARGING, "", "");


### PR DESCRIPTION
The info screens (when pressing the control button) show the current charging state.
This state was not always updated, depending on the current state of the UI state machine.

Fixes #5