### PR TITLE
fix: PRONTO code parsing with trailing whitespace

### DIFF
--- a/components/common/string_util.cpp
+++ b/components/common/string_util.cpp
@@ -6,6 +6,8 @@
 
 #include <string.h>
 
+#include <algorithm>
+#include <cctype>
 #include <iomanip>
 #include <locale>
 #include <sstream>
@@ -43,4 +45,33 @@ int replacechar(char *str, char orig, char rep) {
         n++;
     }
     return n;
+}
+
+// @see Trim functions from: https://stackoverflow.com/a/217605
+void ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) { return !std::isspace(ch); }));
+}
+
+void rtrim(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), s.end());
+}
+
+void trim(std::string &s) {
+    rtrim(s);
+    ltrim(s);
+}
+
+std::string ltrim_copy(std::string s) {
+    ltrim(s);
+    return s;
+}
+
+std::string rtrim_copy(std::string s) {
+    rtrim(s);
+    return s;
+}
+
+std::string trim_copy(std::string s) {
+    trim(s);
+    return s;
 }

--- a/components/common/string_util.h
+++ b/components/common/string_util.h
@@ -27,3 +27,21 @@ std::string toPrintableString(const uint8_t *buf, size_t len);
 /// @param rep replacement character
 /// @return number of characters replaced
 int replacechar(char *str, char orig, char rep);
+
+/// Trim from the start (in place)
+void ltrim(std::string &s);
+
+/// Trim from the end (in place)
+void rtrim(std::string &s);
+
+// Trim from both ends (in place)
+void trim(std::string &s);
+
+// Trim from the start (copying)
+std::string ltrim_copy(std::string s);
+
+// Trim from the end (copying)
+std::string rtrim_copy(std::string s);
+
+// Trim from both ends (copying)
+std::string trim_copy(std::string s);

--- a/components/infrared/ir_codes.cpp
+++ b/components/infrared/ir_codes.cpp
@@ -8,6 +8,10 @@
 
 #include <climits>
 
+#include "esp_log.h"
+
+static const char *TAG = "IR";
+
 uint32_t parseUint32(const char *number, int *error, int base) {
     if (number == NULL) {
         if (error != NULL) {
@@ -138,6 +142,7 @@ uint16_t *prontoBufferToArray(const char *msg, char separator, uint16_t *codeCou
     // - preamble of 4 (raw, frequency, # code pairs sequence 1, # code pairs sequence 2)
     // - 1 code pair
     if (count < 6) {
+        ESP_LOGW(TAG, "PRONTO requires at least 6 burst pairs. Parsed: %d", count);
         return NULL;
     }
 
@@ -146,6 +151,7 @@ uint16_t *prontoBufferToArray(const char *msg, char separator, uint16_t *codeCou
         if (memError) {
             *memError = 1;
         }
+        ESP_LOGE(TAG, "Error parsing PRONTO: memory error");
         return NULL;
     }
 
@@ -169,6 +175,7 @@ uint16_t *prontoBufferToArray(const char *msg, char separator, uint16_t *codeCou
     // Only raw pronto codes are supported
     if (codeArray[0] != 0) {
         free(codeArray);
+        ESP_LOGW(TAG, "Only raw pronto codes are supported! %d", codeArray[0]);
         return NULL;
     }
 
@@ -179,11 +186,13 @@ uint16_t *prontoBufferToArray(const char *msg, char separator, uint16_t *codeCou
 
     if (seq1Len > 0 && seq1Len + seq1Start > count) {
         free(codeArray);
+        ESP_LOGW(TAG, "Invalid PRONTO sequence 1: seq1Len=%d, seq1Start=%d, count=%d", seq1Len, seq1Start, count);
         return NULL;
     }
 
     if (seq2Len > 0 && seq2Len + seq2Start > count) {
         free(codeArray);
+        ESP_LOGW(TAG, "Invalid PRONTO sequence 2: seq2Len=%d, seq2Start=%d, count=%d", seq2Len, seq2Start, count);
         return NULL;
     }
 

--- a/components/infrared/service_ir.cpp
+++ b/components/infrared/service_ir.cpp
@@ -456,7 +456,7 @@ void InfraredService::send_ir_f(void *param) {
                 // operate directly on the underlaying message buffer: avoid std::string allocations from using
                 // "message.substring"!
                 auto      msg = pIrMsg->message.c_str();
-                uint16_t  count;
+                uint16_t  count = 0;
                 int       memError;
                 uint16_t *code_array = prontoBufferToArray(msg, separator, &count, &memError);
                 if (!(code_array == NULL || count == 0)) {

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -21,6 +21,7 @@
 #include "led_pattern.h"
 #include "network.h"
 #include "service_ir.h"
+#include "string_util.h"
 #include "uc_events.h"
 
 static const char *const TAG = "API";
@@ -425,6 +426,9 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         std::string ir_code = cjson_get_string(root, "code", "");
         std::string format = cjson_get_string(root, "format", "");
         uint16_t    response = 400;
+
+        // make sure there are no leading or trailing spaces that could interfere with PRONTO parsing
+        trim(ir_code);
 
         ESP_LOGD(TAG, "IR Send, format=%s, code=%s", format.c_str(), ir_code.c_str());
 

--- a/test/infrared/CMakeLists.txt
+++ b/test/infrared/CMakeLists.txt
@@ -1,10 +1,12 @@
 file(GLOB SRCS *.cpp)
+file(GLOB MOCK_SRCS ../mocks/*.c)
 
 enable_testing()
 
 add_executable(
   infrared
   ${SRCS}
+  ${MOCK_SRCS}
   ../../components/infrared/ir_codes.cpp
   ../../components/infrared/globalcache.cpp
 )

--- a/test/infrared/test_ir_codes.cpp
+++ b/test/infrared/test_ir_codes.cpp
@@ -197,6 +197,19 @@ TEST(IrCodesTest, ProntoBufferToArray) {
     free(buffer);
 }
 
+TEST(IrCodesTest, ProntoBufferToArrayWithTrailingWhitespace) {
+    uint16_t    codeCount;
+    int         memError;
+    const char* msg =
+        "0000,0073,0000,000b,0020,0020,0040,0040,0040,0020,0020,0020,0020,0020,0020,0020,0020,0020,0020,0040,0020,0020,"
+        "0040,0040,0020,09b7 ";
+    auto buffer = prontoBufferToArray(msg, ',', &codeCount, &memError);
+    EXPECT_EQ(0, memError);
+    EXPECT_NE(buffer, nullptr);
+    EXPECT_NE(codeCount, 11) << "Expected 11 burst pairs";
+    free(buffer);
+}
+
 TEST(IrCodesTest, GlobalCacheBufferToArrayEmptyInput) {
     uint16_t codeCount;
     EXPECT_EQ(globalCacheBufferToArray("", &codeCount), nullptr);

--- a/test/mocks/esp_log.h
+++ b/test/mocks/esp_log.h
@@ -1,5 +1,10 @@
 #pragma once
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief Log level
  *
@@ -23,3 +28,7 @@ void test_log(int level, const char* format, ...);
 #define ESP_LOGW( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN,    tag, format, ##__VA_ARGS__)
 #define ESP_LOGI( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_INFO,    tag, format, ##__VA_ARGS__)
 #define ESP_LOGD( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_DEBUG,   tag, format, ##__VA_ARGS__)
+
+#ifdef __cplusplus
+ }
+#endif


### PR DESCRIPTION
PRONTO codes can be separated with a space or a comma. The code parsing fails if the message has leading or trailing whitespace using a comma separator.

- Trim the code to make sure parsing works correctly.
- Add log messages for PRONTO parsing errors.

Fixes #10