### PR TITLE
fix: send authentication error message response

### DIFF
--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -296,8 +296,10 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
                 ret = ESP_OK;
             }
         } else {
-            // invalid token: disconnect
+            // invalid token
             cJSON_AddStringToObject(responseDoc, msgError, "Invalid token");
+            // don't disconnect, otherwise response is not sent back
+            ret = ESP_OK;
         }
 
         goto send_response;


### PR DESCRIPTION
Keep WebSocket session open if authentication message fails.
This allows the web-server to send back the error response. The Remote Two/3 devices will disconnect the WS connection.
Fixes #15