### PR TITLE
feat: show over current error on LCD

### DIFF
--- a/components/display/src/EventParameter.cpp
+++ b/components/display/src/EventParameter.cpp
@@ -36,6 +36,11 @@ EventParameter::EventParameter(ui_event_queue_message* event) : icon_(UI_ICON_NO
                     snprintf(buf, sizeof(buf), "%ld.%02ld V", event_error->value / 1000,
                              (event_error->value % 1000) / 10);
                     message_ = buf;
+                } else if (event_error->error == UC_ERROR_OVER_CURRENT) {
+                    title_ = "CHG OFF";
+                    char buf[16];
+                    snprintf(buf, sizeof(buf), "%ld mA", event_error->value);
+                    message_ = buf;
                 } else {
                     title_ = std::to_string(event_error->error);
                     if (event_error->esp_err != ESP_FAIL) {

--- a/components/preferences/uc_errors.h
+++ b/components/preferences/uc_errors.h
@@ -25,6 +25,8 @@ typedef enum uc_errors {
     UC_ERROR_INIT_PORT2_ADC,
     /// Low input voltage detected. Measured voltage is stored in uc_event_error_t.value field.
     UC_ERROR_VCC_LOW = 28,
+    /// Over-current detected. Measured value corresponding to mA is stored in uc_event_error_t.value field.
+    UC_ERROR_OVER_CURRENT,
     UC_ERROR_IR_LEARN_UNKNOWN = 100,
     UC_ERROR_IR_LEARN_INVALID,
     UC_ERROR_IR_LEARN_OVERFLOW

--- a/components/preferences/uc_events.c
+++ b/components/preferences/uc_events.c
@@ -43,8 +43,6 @@ const char* uc_event_id_to_string(uc_event_id_t event_id) {
             return "CHARGING_ON";
         case UC_EVENT_CHARGING_OFF:
             return "CHARGING_OFF";
-        case UC_EVENT_OVER_CURRENT:
-            return "OVER_CURRENT";
         case UC_EVENT_IR_LEARNING_START:
             return "IR_LEARNING_START";
         case UC_EVENT_IR_LEARNING_OK:

--- a/components/preferences/uc_events.h
+++ b/components/preferences/uc_events.h
@@ -55,7 +55,6 @@ typedef enum {
     UC_EVENT_CHARGING_ON,
     /// Remote device charging stopped event.
     UC_EVENT_CHARGING_OFF,
-    UC_EVENT_OVER_CURRENT,  // TODO not yet fully implemented
     /// IR learning mode started event.
     UC_EVENT_IR_LEARNING_START,
     /// Sucessfully learned an IR code event. Uses event payload `uc_event_ir_t`.

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -72,7 +72,7 @@ menu "UC Dock"
 	config UCD_CHARGER_PERIOD
 		int "Charger monitor polling in ms"
 		range 20 10000
-		default 100
+		default 500
 		help
 			Polling interval in ms of the charger monitor.
 

--- a/main/charger.cpp
+++ b/main/charger.cpp
@@ -71,8 +71,10 @@ bool RemoteCharger::checkOverCurrent(int voltage) {
     // Charging current too high: switch off charging!
     gpio_set_level(CHARGING_ENABLE, 0);
     ESP_LOGE(TAG, "Charging overcurrent protection: shut off charger! Detected charging current: %umA", voltage * 10);
+
+    uc_event_error_t event = {.error = UC_ERROR_OVER_CURRENT, .esp_err = 0, .value = voltage * 10, .fatal = true};
     ESP_ERROR_CHECK_WITHOUT_ABORT(
-        esp_event_post(UC_DOCK_EVENTS, UC_EVENT_OVER_CURRENT, NULL, 0, pdMS_TO_TICKS(10 * 1000)));
+        esp_event_post(UC_DOCK_EVENTS, UC_EVENT_ERROR, &event, sizeof(event), pdMS_TO_TICKS(10 * 1000)));
 
     return true;
 }


### PR DESCRIPTION
In case of an over-current error, show an error message on the display:
- Title: `CHG OFF`
- 2nd line: measured mA

This is a fatal error and doesn't get cleared.
The dock needs to be restarted for the charging to be enabled again.

Change charger polling interval to 500ms

Closes #17 