### PR TITLE
refactor: max charging current

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -104,7 +104,7 @@ menu "UC Dock"
 	config UCD_CHARGER_MAX_CURRENT_MA
 		int "Maximum charging curent in mA"
 		range 1000 2000 
-		default 1700
+		default 1850
 		help
 			Overcurrent protection to shut off charging.
 		


### PR DESCRIPTION
Increase max charger current to 1850 mA.
At remote power up the wifi controller can draw up to 700mA for a short time, which might trigger the over-current protection.