### PR TITLE
Use pinned clang-format version in GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
         - 'test/**'
         - 'components/**'
         - 'sdkconfig*'
-        - '.github/**/*.yml'
+        - '.github/workflows/build.yml'
 
   pull_request:
     types: [ opened, synchronize, reopened ]

--- a/.github/workflows/code_guidelines.yml
+++ b/.github/workflows/code_guidelines.yml
@@ -4,6 +4,7 @@ name: Code Guidelines
 on:
   push:
     paths:
+      - .github/workflows/code_guidelines.yml
       - .clang-format*
       - components/**.c*
       - components/**.h
@@ -11,6 +12,7 @@ on:
       - main/**.h
   pull_request:
     paths:
+      - .github/workflows/code_guidelines.yml
       - .clang-format*
       - components/**.c*
       - components/**.h

--- a/.github/workflows/code_guidelines.yml
+++ b/.github/workflows/code_guidelines.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: python -m pip install clang-format
+      - run: python -m pip install clang-format==20.1.8
       - name: clang-format
         run: |
           ./code_style.sh --check


### PR DESCRIPTION
The newly released v21 reports too many issues, or the configuration is no longer compatible.
Workaround: use pinned version.

Also run code checks if workflow file has changed.

