### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+---
+
+## Beta Release 0.8.0
 ### Fixed
-- Microsecond delay function used for sending IR codes ([#34](https://github.com/unfoldedcircle/ucd3-firmware/pull/34), [feature-and-bug-tracker#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).
+- Delay function used for sending IR codes was inaccurate for delays greater than 16ms, causing issues for certain IR protocols and native IR repeats ([#34](https://github.com/unfoldedcircle/ucd3-firmware/pull/34), [feature-and-bug-tracker#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).
 - Stop active IR repeat if WebSocket client disconnects.
 - Memory leak in async ir_send responses.
 
@@ -22,9 +25,7 @@ _Changes in the next release_
 ### Changed
 - Support higher modulation frequencies and better PWM precision for sending IR ([#29](https://github.com/unfoldedcircle/ucd3-firmware/pull/29)).
 - Enhance IR repeat functionality ([#35](https://github.com/unfoldedcircle/ucd3-firmware/pull/35)).
-- Do not enter WiFi setup mode if connection setup failed ([feature-and-bug-tracker#612](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/612))
-
----
+- Do not enter WiFi setup mode if connection setup failed ([feature-and-bug-tracker#612](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/612)).
 
 ## Beta Release 0.7.1
 ### Added

--- a/doc/release/release-notes_de.md
+++ b/doc/release/release-notes_de.md
@@ -1,3 +1,15 @@
+## Beta Release 0.8.0
+### Fehlerbehebungen
+- Die Verzögerungsfunktion für das Senden von IR-Codes war bei Verzögerungen von mehr als 16 ms ungenau, was bei bestimmten IR-Protokollen und nativen IR-Wiederholungen zu Problemen führte ([#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).
+- Aktive IR-Wiederholung stoppen, wenn der WebSocket-Client die Verbindung trennt.
+- Allgemeine Stabilitätsverbesserungen.
+
+### Neue Funktionen
+- Status-LED-Muster für Dock-Einrichtung, IR-Lernen und OTA.
+
+### Geändert
+- Nicht in den WiFi-Einrichtungsmodus wechseln, wenn die Einrichtung der Verbindung fehlgeschlagen ist ([#612](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/612))
+
 ## Beta Release 0.7.1
 ### Geändert
 - Anhebung der Überstrombegrenzung auf 1850mA ([#30](https://github.com/unfoldedcircle/ucd3-firmware/pull/30)).

--- a/doc/release/release-notes_en.md
+++ b/doc/release/release-notes_en.md
@@ -1,3 +1,15 @@
+## Beta Release 0.8.0
+### Fixed
+- Delay function used for sending IR codes was inaccurate for delays greater than 16ms, causing issues for certain IR protocols and native IR repeats ([#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).
+- Stop active IR repeat if the WebSocket client disconnects.
+- General stability improvements.
+
+### Added
+- Status led patterns for dock setup, IR learning and OTA.
+
+### Changed
+- Not entering WiFi setup mode if connection setup failed ([#612](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/612)).
+
 ## Beta Release 0.7.1
 ### Changed
 - Increase of overcurrent limitation to 1850mA ([#30](https://github.com/unfoldedcircle/ucd3-firmware/pull/30)).


### PR DESCRIPTION
## Beta Release 0.8.0
### Fixed
- Delay function used for sending IR codes was inaccurate for delays greater than 16ms, causing issues for certain IR protocols and native IR repeats ([#34](https://github.com/unfoldedcircle/ucd3-firmware/pull/34), [feature-and-bug-tracker#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).
- Stop active IR repeat if WebSocket client disconnects.
- Memory leak in async ir_send responses.

### Added
- Optional system runtime statistics ([#28](https://github.com/unfoldedcircle/ucd3-firmware/pull/28)).
- Status led patterns for dock setup, IR learning and OTA ([#37](https://github.com/unfoldedcircle/ucd3-firmware/pull/37)).
- Sending an IR code for a specific time.

### Changed
- Support higher modulation frequencies and better PWM precision for sending IR ([#29](https://github.com/unfoldedcircle/ucd3-firmware/pull/29)).
- Enhance IR repeat functionality ([#35](https://github.com/unfoldedcircle/ucd3-firmware/pull/35)).
- Do not enter WiFi setup mode if connection setup failed ([feature-and-bug-tracker#612](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/612)).

