### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ _Changes in the next release_
 
 ---
 
+## Beta Release 0.8.1
+### Changed
+- Increase of overcurrent limitation to 2000mA ([#41](https://github.com/unfoldedcircle/ucd3-firmware/pull/41)).
+
 ## Beta Release 0.8.0
 ### Fixed
 - Delay function used for sending IR codes was inaccurate for delays greater than 16ms, causing issues for certain IR protocols and native IR repeats ([#34](https://github.com/unfoldedcircle/ucd3-firmware/pull/34), [feature-and-bug-tracker#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).

--- a/doc/release/release-notes_de.md
+++ b/doc/release/release-notes_de.md
@@ -1,3 +1,7 @@
+## Beta Release 0.8.1
+### Geändert
+- Anhebung der Überstrombegrenzung auf 2000mA.
+
 ## Beta Release 0.8.0
 ### Fehlerbehebungen
 - Die Verzögerungsfunktion für das Senden von IR-Codes war bei Verzögerungen von mehr als 16 ms ungenau, was bei bestimmten IR-Protokollen und nativen IR-Wiederholungen zu Problemen führte ([#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).

--- a/doc/release/release-notes_en.md
+++ b/doc/release/release-notes_en.md
@@ -1,3 +1,7 @@
+## Beta Release 0.8.1
+### Changed
+- Increase of overcurrent limitation to 2000mA.
+
 ## Beta Release 0.8.0
 ### Fixed
 - Delay function used for sending IR codes was inaccurate for delays greater than 16ms, causing issues for certain IR protocols and native IR repeats ([#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).


### PR DESCRIPTION
## Beta Release 0.8.1
### Changed
- Increase of overcurrent limitation to 2000mA ([#41](https://github.com/unfoldedcircle/ucd3-firmware/pull/41)).
