### PR TITLE
fix: memory leak in BLE device name advertisement

### DIFF
--- a/components/network/src/wifi_provisioning.c
+++ b/components/network/src/wifi_provisioning.c
@@ -577,7 +577,10 @@ esp_err_t start_improv(void) {
 
     // TODO does this affect advertisement fields?
     // Default name is "nimble", which suddenly appeared in macOS LightBlue scan results if device_name was not set!
-    ESP_RETURN_ON_ERROR(ble_svc_gap_device_name_set(create_device_name()), TAG, "Failed to set GAP device name");
+    char *device_name = create_device_name();
+    int   res = ble_svc_gap_device_name_set(device_name);
+    free(device_name);
+    ESP_RETURN_ON_ERROR(res, TAG, "Failed to set GAP device name");
 
     ble_svc_gap_init();
     ble_svc_gatt_init();


### PR DESCRIPTION
The `create_device_name` function uses `asprintf` to allocate a string, but the returned pointer is never freed after being passed to `ble_svc_gap_device_name_set`. While the latter might copy the string, the original allocation in `create_device_name` remains in memory.