### PR TITLE
feat: enable TCP keep alive and connection lru purge

### DIFF
--- a/components/webserver/WebServer.cpp
+++ b/components/webserver/WebServer.cpp
@@ -31,6 +31,15 @@ WebServer::WebServer()
     // pin task to main core to not interfere with IR sending
     config_.core_id = 0;
     config_.max_open_sockets = CONFIG_UCD_WEB_MAX_OPEN_SOCKETS;
+    // purge oldest connection if max open sockets is reached
+    config_.lru_purge_enable = true;
+    // Enable tcp keep-alive: if a client disconnects ungracefully (e.g., moves out of Wi-Fi range, loses power),
+    // the server may keep the socket in the `ESTABLISHED` state indefinitely (until the default TCP timeout,
+    // which can be hours), consuming a socket slot.
+    config_.keep_alive_enable = true;
+    config_.keep_alive_idle = 30;
+    config_.keep_alive_interval = 10;
+    config_.keep_alive_count = 3;
 }
 
 WebServer::~WebServer() {

--- a/tools/ws_count.js
+++ b/tools/ws_count.js
@@ -4,8 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Dock WebSocket connection test.
-// Verifies that oldest connecton automatically closes for new connectons after
-// connection limit is reached.
+// Verifies that oldest connection automatically closes for new connections
+// after connection limit is reached.
 //
 // Usage:
 // node ws_count.js <DOCK_IP>

--- a/tools/ws_count.js
+++ b/tools/ws_count.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// SPDX-FileCopyrightText: Copyright (c) 2026 Unfolded Circle ApS and/or its affiliates <hello@unfoldedcircle.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Dock WebSocket connection test.
+// Verifies that oldest connecton automatically closes for new connectons after
+// connection limit is reached.
+//
+// Usage:
+// node ws_count.js <DOCK_IP>
+// 
+// Example:
+// node ws_count.js /192.168.1.234
+//
+
+const TARGET_PORT = 80;
+const TARGET_PATH = '/ws';
+const CONNECTION_COUNT = 100;
+const HOLD_MS = 5000;
+
+const opened = [];
+const pending = [];
+
+if (process.argv.length !== 3) {
+    console.error('Expected exactly one argument with the dock IP address!');
+    process.exit(1);
+}
+
+for (let i = 0; i < CONNECTION_COUNT; i++) {
+  pending.push(new Promise((resolve) => {
+    let settled = false;
+    const ws = new WebSocket(`ws://${process.argv[2]}:${TARGET_PORT}${TARGET_PATH}`);
+
+    const finish = () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    };
+
+    ws.addEventListener('open', () => {
+      opened.push(ws);
+      console.log(`Connected ${i + 1}`);
+      finish();
+    }, { once: true });
+
+    ws.addEventListener('close', () => {
+      opened.pop(ws);
+      console.log(`Closed ${i + 1}`);
+      finish();
+    }, { once: true });
+
+    ws.addEventListener('error', (err) => {
+      console.log(`Failed at ${i + 1}: ${err?.message || err}`);
+      finish();
+    }, { once: true });
+  }));
+  await new Promise((resolve) => setTimeout(resolve, 200));
+}
+
+await Promise.all(pending);
+
+setTimeout(() => {
+  for (const ws of opened) {
+    ws.close(1000, 'test complete');
+  }
+}, HOLD_MS);


### PR DESCRIPTION
Improve socket connection handling with LRU purging and TCP keep alive:

If the max_open_sockets is reached, the server will reject new connections. Without LRU purging, it will not close older, potentially inactive, or "ghost" connections to make room for new ones.

If a client disconnects ungracefully (e.g., moves out of Wi-Fi range, loses power), the server may keep the socket in the `ESTABLISHED` state indefinitely (until the default TCP timeout, which can be hours), consuming a socket slot. Set first probe after 30s idle, retry every 10s, and give up after 3 probes. This yields a detection window of about 30+3×10=60 seconds for a completely dead idle connection, which is:
- Short enough to prevent long-lived zombie sockets over days.
- Long enough that “normal” Wi‑Fi hiccups of a few seconds or brief AP roaming are less likely to kill connections spuriously.