### PR TITLE
refactor: increase max sockets from 10 to 32

### DIFF
--- a/components/infrared/Kconfig.projbuild
+++ b/components/infrared/Kconfig.projbuild
@@ -1,0 +1,11 @@
+menu "UC GlobalCache server"
+
+	config UCD_GLOBALCACHE_MAX_CLIENTS
+		int "Max number of TCP clients"
+		range 1 16
+		default 8
+		help
+			Max number of TCP clients connected at any time
+			(1 additional socket is required for the TCP server)
+
+endmenu

--- a/components/infrared/globalcache_server.cpp
+++ b/components/infrared/globalcache_server.cpp
@@ -21,13 +21,12 @@
 #include "esp_log.h"
 
 #include "globalcache.h"
+#include "sdkconfig.h"
 #include "string_util.h"
 #include "uc_events.h"
 
 // TODO(#28) use IDF LWIP_IPV6 & LWIP_IPV4 and test IPv6
 #define USE_IPV4
-
-#define MAX_TCP_CLIENT_COUNT 8
 
 #define TCP_API_PORT 4998
 #define KEEPALIVE_IDLE 5
@@ -109,7 +108,8 @@ void GlobalCacheServer::tcp_server_task(void *param) {
 
     GlobalCacheServer *gc = reinterpret_cast<GlobalCacheServer *>(param);
 
-    clientCountSemaphore = xSemaphoreCreateCounting(MAX_TCP_CLIENT_COUNT, MAX_TCP_CLIENT_COUNT);
+    clientCountSemaphore =
+        xSemaphoreCreateCounting(CONFIG_UCD_GLOBALCACHE_MAX_CLIENTS, CONFIG_UCD_GLOBALCACHE_MAX_CLIENTS);
     if (clientCountSemaphore == NULL) {
         ESP_LOGE(TAG_GC, "Error starting server: unable to create client semaphore");
         vTaskDelete(NULL);

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -59,7 +59,25 @@ CONFIG_BT_NIMBLE_ENABLED=y
 #
 CONFIG_LWIP_LOCAL_HOSTNAME="ucd3"
 # CONFIG_LWIP_DNS_SUPPORT_MDNS_QUERIES is not set
-CONFIG_LWIP_MAX_SOCKETS=16
+# Global socket pool. Worst case:
+#  21 web-server (16 WS + 2 REST + 3 internal)
+# + 7 GlobalCache server (6 clients + 1 server socket)
+# + 4 system services (mDNS, SNTP, DHCP, DNS, ...)
+# = 32
+CONFIG_LWIP_MAX_SOCKETS=32
+
+# Maximum number of web-server sockets. 3 more internal sockets are used.
+CONFIG_UCD_WEB_MAX_OPEN_SOCKETS=18
+# Maximum number of GlobalCache TCP clients. 1 more socket is required for the listening socket.
+CONFIG_UCD_GLOBALCACHE_MAX_CLIENTS=6
+
+#
+# TCP
+#
+# Maximum number of simultaneously active TCP connections
+CONFIG_LWIP_MAX_ACTIVE_TCP=32
+# Maximum number of simultaneously listening TCP connections (leave at default): WebSocket API, webserver, GlobalCache server
+CONFIG_LWIP_MAX_LISTENING_TCP=16
 
 #
 # SNTP


### PR DESCRIPTION
Increase the global socket pool and the maximum of simultaneously active sockets to 32.

- Increase webserver sockets from 7 to 18
  - The sockets are shared between WebSocket and REST clients.
- Decrease GlobalCache TCP clients from 8 to 6.
  - This is now adjustable in Kconfig.

The socket pool size of 32 has been chosen for a good compromise of heap memory usage vs expected number of clients.
Every socket and TCP communication requires heap memory.

Socket pool calculation for 32 sockets:
-  21 web-server (16 WS + 2 REST + 3 internal)
-  7 GlobalCache server (6 clients + 1 server socket)
-  4 system services (mDNS, SNTP, DHCP, DNS, ...)

Notes:
- Further increasing the size, especially when going ~ > 60 sockets, requires adjusting  FD_SETSIZE and enabling SPRAM for ethernet buffers.
- Patching IDF Kconfig for increasing LWIP_MAX_SOCKETS is no longer required for latest IDF versions > 5.2

Closes #8 