### PR TITLE
build: Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,20 @@ _Changes in the next release_
 
 ---
 
-## Beta Release 0.8.2
+## Release 0.9.0 - 2026-04-28
+### Fixed
+- Double allocation of eth_handle ([#53](https://github.com/unfoldedcircle/ucd3-firmware/pull/53)).
+- Memory leak in BLE device name advertisement ([#54](https://github.com/unfoldedcircle/ucd3-firmware/pull/54)).
+- Memory leak in WebSocket send, buffer under-read in file ext check ([#55](https://github.com/unfoldedcircle/ucd3-firmware/pull/55)).
+- Semaphore and socket leak in GlobalCache server ([#56](https://github.com/unfoldedcircle/ucd3-firmware/pull/56)).
+
+### Changed
+- Update GitHub actions, clean up ([#57](https://github.com/unfoldedcircle/ucd3-firmware/pull/57)).
+- Enable TCP keep alive and connection lru purge ([#58](https://github.com/unfoldedcircle/ucd3-firmware/pull/58)).
+- Disconnect unauthenticated WS clients after 30s ([#59](https://github.com/unfoldedcircle/ucd3-firmware/pull/59)).
+- Increase max sockets from 10 to 32 ([#60](https://github.com/unfoldedcircle/ucd3-firmware/pull/60)).
+
+## Beta Release 0.8.2 - 2026-02-14
 ### Fixed
 - Improv-wifi RPC response length and checksum calculation ([#47](https://github.com/unfoldedcircle/ucd3-firmware/pull/47)).
 - Correct initial state for inverted IR emitters ([#48](https://github.com/unfoldedcircle/ucd3-firmware/pull/48)).
@@ -25,11 +38,11 @@ _Changes in the next release_
 - SNTP initialization, not displaying an invalid date in the status web-page by @Tosko4 in ([#46](https://github.com/unfoldedcircle/ucd3-firmware/pull/46)).
 - Update GitHub build actions ([#50](https://github.com/unfoldedcircle/ucd3-firmware/pull/50)).
     
-## Beta Release 0.8.1
+## Beta Release 0.8.1 - 2025-11-03
 ### Changed
 - Increase of overcurrent limitation to 2000mA ([#41](https://github.com/unfoldedcircle/ucd3-firmware/pull/41)).
 
-## Beta Release 0.8.0
+## Beta Release 0.8.0 - 2025-09-23
 ### Fixed
 - Delay function used for sending IR codes was inaccurate for delays greater than 16ms, causing issues for certain IR protocols and native IR repeats ([#34](https://github.com/unfoldedcircle/ucd3-firmware/pull/34), [feature-and-bug-tracker#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).
 - Stop active IR repeat if WebSocket client disconnects.
@@ -45,13 +58,13 @@ _Changes in the next release_
 - Enhance IR repeat functionality ([#35](https://github.com/unfoldedcircle/ucd3-firmware/pull/35)).
 - Do not enter WiFi setup mode if connection setup failed ([feature-and-bug-tracker#612](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/612)).
 
-## Beta Release 0.7.1
+## Beta Release 0.7.1 - 2025-08-28
 ### Added
 - Documentation for firmware flashing with esptool and web-serial ([#26](https://github.com/unfoldedcircle/ucd3-firmware/pull/26), [#27](https://github.com/unfoldedcircle/ucd3-firmware/pull/27)).
 ### Changed
 - Increase of overcurrent limitation to 1850mA ([#30](https://github.com/unfoldedcircle/ucd3-firmware/pull/30)).
 
-## Beta Release 0.7.0
+## Beta Release 0.7.0 - 2025-07-17
 ### Fixed
 - External port detection with two blasters.
 - Show error on screen for over-current detection ([#17](https://github.com/unfoldedcircle/ucd3-firmware/issues/17)).
@@ -71,7 +84,7 @@ _Changes in the next release_
 - Use both internal IR outputs if no active output has been specified.
 - Determine vcc charger offset at startup to prevent toggling charging / non charging screens.
 
-## Beta Release 0.6.0
+## Beta Release 0.6.0 - 2025-06-02
 ### Changed
 - Improve auto-detection of external IR-peripherals, including the Dock Two mono-plug IR-emitter.
 - OSS release: squashed and cleaned-up project for public release.

--- a/doc/release/release-notes_de.md
+++ b/doc/release/release-notes_de.md
@@ -1,4 +1,13 @@
-## Beta Release 0.8.2
+## Release 0.9.0 - 2026-04-28
+### Fehlerbehebungen
+- Verschiedene Stabilitätsverbesserungen und automatisches Trennen von hängenden Client-Verbindungen.
+  
+### Geändert
+- Die am wenigsten aktive Client-Verbindung automatisch schließen, wenn keine Verbindungen mehr verfügbar sind ([#58](https://github.com/unfoldedcircle/ucd3-firmware/pull/58)).
+- Nicht authentifizierte Clients nach 30 Sekunden trennen ([#59](https://github.com/unfoldedcircle/ucd3-firmware/pull/59)).
+- Die maximale Anzahl an Client-Verbindungen wurde von 7 auf 18 erhöht ([#60](https://github.com/unfoldedcircle/ucd3-firmware/pull/60)).
+
+## Beta Release 0.8.2 - 2026-02-14
 ### Fehlerbehebungen
 - Korrekter Anfangszustand für IR-LEDs, damit diese nicht leuchten bis ein IR-Befehl gesendet wird ([#48](https://github.com/unfoldedcircle/ucd3-firmware/pull/48)).
 - Allgemeine Fehlerbehebungen und Verbesserungen.
@@ -6,11 +15,11 @@
 ### Geändert
 - SNTP-Initialisierung, keine Anzeige eines ungültigen Datums auf der Status-Webseite. Beigetragen von @Tosko4, danke! ([#46](https://github.com/unfoldedcircle/ucd3-firmware/pull/46)).
 
-## Beta Release 0.8.1
+## Beta Release 0.8.1 - 2025-11-03
 ### Geändert
 - Anhebung der Überstrombegrenzung auf 2000mA.
 
-## Beta Release 0.8.0
+## Beta Release 0.8.0 - 2025-09-23
 ### Fehlerbehebungen
 - Die Verzögerungsfunktion für das Senden von IR-Codes war bei Verzögerungen von mehr als 16 ms ungenau, was bei bestimmten IR-Protokollen und nativen IR-Wiederholungen zu Problemen führte ([#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).
 - Aktive IR-Wiederholung stoppen, wenn der WebSocket-Client die Verbindung trennt.
@@ -22,11 +31,11 @@
 ### Geändert
 - Nicht in den WiFi-Einrichtungsmodus wechseln, wenn die Einrichtung der Verbindung fehlgeschlagen ist ([#612](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/612))
 
-## Beta Release 0.7.1
+## Beta Release 0.7.1 - 2025-08-28
 ### Geändert
 - Anhebung der Überstrombegrenzung auf 1850mA ([#30](https://github.com/unfoldedcircle/ucd3-firmware/pull/30)).
 
-## Beta Release 0.7.0
+## Beta Release 0.7.0 - 2025-07-17
 ### Fehlerbehebungen
 - Automatische Erkennung von zwei IR-Blaster.
 - Fehleranzeige auf dem Bildschirm bei Ladeabschaltung aufgrund von Überstromerkennung ([#501](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/501)).
@@ -43,7 +52,7 @@
 - Verbesserung der Ladestrommessung und der Überstromerkennung zur Vermeidung von Ladeabschaltungen ([#501](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/501)).
 - Bestimmung des Ladespannungs-Offset beim Start, um ein Umschalten zwischen den Lade- und Nichtladebildschirmen zu verhindern.
 
-## Beta Release 0.6.0
+## Beta Release 0.6.0 - 2025-06-02
 ### Fehlerbehebungen
 - Die externen Ports 1 und 2 wurden gemäß Handbuch getauscht: Port 1 befindet sich neben dem Ethernet-Port.
 - Startup-Crash beim Netzwerk-Check, wenn andere Initialisierungen länger dauern als erwartet.

--- a/doc/release/release-notes_en.md
+++ b/doc/release/release-notes_en.md
@@ -1,4 +1,13 @@
-## Beta Release 0.8.2
+## Release 0.9.0 - 2026-04-28
+### Fixed
+- Various stability improvements and automatically releasing stuck client connections.
+
+### Changed
+- Automatically close the least active client connection if no connections are available anymroe ([#58](https://github.com/unfoldedcircle/ucd3-firmware/pull/58)).
+- Disconnect unauthenticated clients after 30s ([#59](https://github.com/unfoldedcircle/ucd3-firmware/pull/59)).
+- Increased max client connections from 7 to 18 ([#60](https://github.com/unfoldedcircle/ucd3-firmware/pull/60)).
+
+## Beta Release 0.8.2 - 2026-02-14
 ### Fixed
 - Correct initial state for IR LEDs so that they do not light up until an IR command is sent ([#48](https://github.com/unfoldedcircle/ucd3-firmware/pull/48)).
 - General fixes and improvements.
@@ -6,11 +15,11 @@
 ### Changed
 - SNTP initialization, not displaying an invalid date in the status web-page. Contributed by @Tosko4, thanks! ([#46](https://github.com/unfoldedcircle/ucd3-firmware/pull/46)).
 
-## Beta Release 0.8.1
+## Beta Release 0.8.1 - 2025-11-03
 ### Changed
 - Increase of overcurrent limitation to 2000mA.
 
-## Beta Release 0.8.0
+## Beta Release 0.8.0 - 2025-09-23
 ### Fixed
 - Delay function used for sending IR codes was inaccurate for delays greater than 16ms, causing issues for certain IR protocols and native IR repeats ([#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).
 - Stop active IR repeat if the WebSocket client disconnects.
@@ -22,11 +31,11 @@
 ### Changed
 - Not entering WiFi setup mode if connection setup failed ([#612](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/612)).
 
-## Beta Release 0.7.1
+## Beta Release 0.7.1 - 2025-08-28
 ### Changed
 - Increase of overcurrent limitation to 1850mA ([#30](https://github.com/unfoldedcircle/ucd3-firmware/pull/30)).
 
-## Beta Release 0.7.0
+## Beta Release 0.7.0 - 2025-07-17
 ### Bug Fixes
 - External port detection with two blasters.
 - Show charger shut off error on screen caused by over-current detection ([#501](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/501)).
@@ -43,7 +52,7 @@
 - Improve charging current measurement and over-current detection to prevent charging shutdowns ([#501](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/501)).
 - Determination of the charging voltage offset at startup to prevent switching between the charging and non-charging screens.
 
-## Beta Release 0.6.0
+## Beta Release 0.6.0 - 2025-06-02
 ### Bug Fixes
 - Switch external ports 1 & 2 according to booklet: port 1 is next to ethernet port.
 - Startup crash in network check if other initializations take longer than expected.


### PR DESCRIPTION
## Release 0.9.0 - 2026-04-28
### Fixed
- Various stability improvements and automatically releasing stuck client connections.

### Changed
- Automatically close the least active client connection if no connections are available anymroe ([#58](https://github.com/unfoldedcircle/ucd3-firmware/pull/58)).
- Disconnect unauthenticated clients after 30s ([#59](https://github.com/unfoldedcircle/ucd3-firmware/pull/59)).
- Increased max client connections from 7 to 18 ([#60](https://github.com/unfoldedcircle/ucd3-firmware/pull/60)).
