### PR TITLE
build: Release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+---
+
+## Release 0.9.1 - 2026-05-18
 ### Fixed
 - IR code validation fails for data value 0 ([#62](https://github.com/unfoldedcircle/ucd3-firmware/issues/62)).
-- OTA image build now supports multiple revisions. No more manual interventions required.
-
----
+- OTA image build now supports multiple revisions. No more manual interventions required ([#64](https://github.com/unfoldedcircle/ucd3-firmware/pull/64)).
 
 ## Release 0.9.0 - 2026-04-28
 ### Fixed

--- a/doc/release/release-notes_de.md
+++ b/doc/release/release-notes_de.md
@@ -1,3 +1,7 @@
+## Release 0.9.1 - 2026-05-18
+### Fehlerbehebungen
+- IR-Codes mit dem Datenwert 0 zulassen, z. B. die Ziffer "0" bei Philips-Fernsehern, die das RC6-Protokoll verwenden ([bug-tracker#721](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/721)).
+
 ## Release 0.9.0 - 2026-04-28
 ### Fehlerbehebungen
 - Verschiedene Stabilitätsverbesserungen und automatisches Trennen von hängenden Client-Verbindungen.
@@ -21,7 +25,7 @@
 
 ## Beta Release 0.8.0 - 2025-09-23
 ### Fehlerbehebungen
-- Die Verzögerungsfunktion für das Senden von IR-Codes war bei Verzögerungen von mehr als 16 ms ungenau, was bei bestimmten IR-Protokollen und nativen IR-Wiederholungen zu Problemen führte ([#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).
+- Die Verzögerungsfunktion für das Senden von IR-Codes war bei Verzögerungen von mehr als 16 ms ungenau, was bei bestimmten IR-Protokollen und nativen IR-Wiederholungen zu Problemen führte ([bug-tracker#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).
 - Aktive IR-Wiederholung stoppen, wenn der WebSocket-Client die Verbindung trennt.
 - Allgemeine Stabilitätsverbesserungen.
 
@@ -29,7 +33,7 @@
 - Status-LED-Muster für Dock-Einrichtung, IR-Lernen und OTA.
 
 ### Geändert
-- Nicht in den WiFi-Einrichtungsmodus wechseln, wenn die Einrichtung der Verbindung fehlgeschlagen ist ([#612](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/612))
+- Nicht in den WiFi-Einrichtungsmodus wechseln, wenn die Einrichtung der Verbindung fehlgeschlagen ist ([bug-tracker#612](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/612))
 
 ## Beta Release 0.7.1 - 2025-08-28
 ### Geändert
@@ -38,9 +42,9 @@
 ## Beta Release 0.7.0 - 2025-07-17
 ### Fehlerbehebungen
 - Automatische Erkennung von zwei IR-Blaster.
-- Fehleranzeige auf dem Bildschirm bei Ladeabschaltung aufgrund von Überstromerkennung ([#501](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/501)).
-- PRONTO-Code-Parsing mit nachgestellten Leerzeichen ([#495](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/495)).
-- Einrichtung mit einem benutzerdefinierten Passwort auf Fernbedienungen mit einer Firmware-Version <= 2.6.1 ([#489](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/489)).
+- Fehleranzeige auf dem Bildschirm bei Ladeabschaltung aufgrund von Überstromerkennung ([#bug-tracker501](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/501)).
+- PRONTO-Code-Parsing mit nachgestellten Leerzeichen ([bug-tracker#495](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/495)).
+- Einrichtung mit einem benutzerdefinierten Passwort auf Fernbedienungen mit einer Firmware-Version <= 2.6.1 ([bug-tracker#489](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/489)).
 - Rückgabe des korrekten Netzwerkverbindungstyps (Ethernet oder WiFi).
 - Anzeige der korrekten Ladeinformationen im Info-Bildschirm beim Drücken der Steuerungstaste.
 - Allgemeine Stabilitätsverbesserungen.
@@ -49,7 +53,7 @@
 - Überprüfung des Ladegeräts auf Unterspannung.
 
 ### Geändert
-- Verbesserung der Ladestrommessung und der Überstromerkennung zur Vermeidung von Ladeabschaltungen ([#501](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/501)).
+- Verbesserung der Ladestrommessung und der Überstromerkennung zur Vermeidung von Ladeabschaltungen ([bug-tracker#501](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/501)).
 - Bestimmung des Ladespannungs-Offset beim Start, um ein Umschalten zwischen den Lade- und Nichtladebildschirmen zu verhindern.
 
 ## Beta Release 0.6.0 - 2025-06-02

--- a/doc/release/release-notes_en.md
+++ b/doc/release/release-notes_en.md
@@ -1,3 +1,7 @@
+## Release 0.9.1 - 2026-05-18
+### Fixed
+- Allow IR codes with a data value of 0, such as the digit "0" on Philips TVs that use the RC6 protocol ([bug-tracker#721](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/721)).
+
 ## Release 0.9.0 - 2026-04-28
 ### Fixed
 - Various stability improvements and automatically releasing stuck client connections.
@@ -21,7 +25,7 @@
 
 ## Beta Release 0.8.0 - 2025-09-23
 ### Fixed
-- Delay function used for sending IR codes was inaccurate for delays greater than 16ms, causing issues for certain IR protocols and native IR repeats ([#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).
+- Delay function used for sending IR codes was inaccurate for delays greater than 16ms, causing issues for certain IR protocols and native IR repeats ([bug-tracker#484](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/484)).
 - Stop active IR repeat if the WebSocket client disconnects.
 - General stability improvements.
 
@@ -29,7 +33,7 @@
 - Status led patterns for dock setup, IR learning and OTA.
 
 ### Changed
-- Not entering WiFi setup mode if connection setup failed ([#612](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/612)).
+- Not entering WiFi setup mode if connection setup failed ([bug-tracker#612](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/612)).
 
 ## Beta Release 0.7.1 - 2025-08-28
 ### Changed
@@ -38,9 +42,9 @@
 ## Beta Release 0.7.0 - 2025-07-17
 ### Bug Fixes
 - External port detection with two blasters.
-- Show charger shut off error on screen caused by over-current detection ([#501](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/501)).
-- PRONTO code parsing with trailing whitespace ([#495](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/495)).
-- Setup with a custom password on Remotes runnig firmware version <= 2.6.1 ([#489](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/489)).
+- Show charger shut off error on screen caused by over-current detection ([bug-tracker#501](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/501)).
+- PRONTO code parsing with trailing whitespace ([bug-tracker#495](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/495)).
+- Setup with a custom password on Remotes runnig firmware version <= 2.6.1 ([bug-tracker#489](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/489)).
 - Return correct network connection type (Ethernet or WiFi).
 - Show correct charging information in info screen when pressing the control button.
 - General stability improvements.


### PR DESCRIPTION
## Release 0.9.1 - 2026-05-18
### Fixed
- IR code validation fails for data value 0 ([#62](https://github.com/unfoldedcircle/ucd3-firmware/issues/62)).
- OTA image build now supports multiple revisions. No more manual interventions required ([#64](https://github.com/unfoldedcircle/ucd3-firmware/pull/64)).
