### PR TITLE
refactor: unify firmware revisions 4 and 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Changed
+- Unify firmware revisions 4 and 6 ([#66](https://github.com/unfoldedcircle/ucd3-firmware/pull/66)).
+
 ---
 
 ## Release 0.9.1 - 2026-05-18

--- a/components/external_port/external_port.cpp
+++ b/components/external_port/external_port.cpp
@@ -427,7 +427,7 @@ void ExternalPort::enableGround(bool enable) {
 
 void ExternalPort::enable5V(bool enable) {
     // inverted logic depending on board revision!
-    if (SWITCH_EXT_INVERTED) {
+    if (board_is_switch_ext_inverted()) {
         enable = !enable;
     }
     gpio_set_level(config_.gpio_5v_switch, enable ? 1 : 0);

--- a/components/infrared/service_ir.cpp
+++ b/components/infrared/service_ir.cpp
@@ -297,15 +297,16 @@ GpioPinMask InfraredService::createIrPinMask(bool internal_side, bool internal_t
         }
     }
 
-#ifdef IR_SEND_PIN_INT_TOP
     if (internal_top) {
-        if (IR_SEND_PIN_INT_TOP_INVERTED) {
-            mask.w1tc |= (1ULL << IR_SEND_PIN_INT_TOP);
-        } else {
-            mask.w1ts |= (1ULL << IR_SEND_PIN_INT_TOP);
+        gpio_num_t ir_send_pin_int_top = board_get_ir_send_pin_int_top();
+        if (ir_send_pin_int_top != GPIO_NUM_NC) {
+            if (IR_SEND_PIN_INT_TOP_INVERTED) {
+                mask.w1tc |= (1ULL << ir_send_pin_int_top);
+            } else {
+                mask.w1ts |= (1ULL << ir_send_pin_int_top);
+            }
         }
     }
-#endif
 
     if (ext1_gpio_signal != GPIO_NUM_NC) {
         if (ext1_gpio_enable != GPIO_NUM_NC) {

--- a/components/network/Kconfig.projbuild
+++ b/components/network/Kconfig.projbuild
@@ -64,11 +64,11 @@ menu "UC Dock Network Configuration"
 
 	config UCD_ETH_SPI_CS0_GPIO
 		int "SPI CS0 GPIO number for SPI Ethernet module"
-		range ENV_GPIO_RANGE_MIN ENV_GPIO_OUT_RANGE_MAX
-		default 14 if UCD_HW_REVISION_6
-		default 6
+		range -1 ENV_GPIO_OUT_RANGE_MAX
+		default -1
 		help
 			Set the GPIO number used by SPI CS0, i.e. Chip Select associated with the first SPI Eth module.
+			Set -1 to use GPIO number based on hardware revision 4 or 6.
 
 	config UCD_ETH_SPI_INT0_GPIO
 		int "Interrupt GPIO number SPI Ethernet module"

--- a/components/network/src/network_ethernet.c
+++ b/components/network/src/network_ethernet.c
@@ -159,7 +159,7 @@ esp_err_t eth_init(esp_eth_handle_t *eth_handle_out) {
     // Init specific SPI Ethernet module configuration from Kconfig (CS GPIO, Interrupt GPIO, etc.)
     spi_eth_module_config_t spi_eth_module_config = {0};
 
-    spi_eth_module_config.spi_cs_gpio = CONFIG_UCD_ETH_SPI_CS0_GPIO;
+    spi_eth_module_config.spi_cs_gpio = board_get_spi_cs();
     spi_eth_module_config.int_gpio = CONFIG_UCD_ETH_SPI_INT0_GPIO;
     spi_eth_module_config.polling_ms = CONFIG_UCD_ETH_SPI_POLLING0_MS;
     spi_eth_module_config.phy_reset_gpio = CONFIG_UCD_ETH_SPI_PHY_RST0_GPIO;

--- a/components/preferences/CMakeLists.txt
+++ b/components/preferences/CMakeLists.txt
@@ -1,5 +1,6 @@
 idf_component_register(
     SRCS
+    "board.c"
     "config.cpp"
     "efuse.cpp"
     "efuse_user.c"

--- a/components/preferences/board.c
+++ b/components/preferences/board.c
@@ -40,7 +40,7 @@ static adc_unit_t s_charging_current_adc_unit = ADC_UNIT_2;
 static adc_channel_t s_charging_current_adc_ch = ADC_CHANNEL_3;
 
 int read_efuse_revision() {
-    char revision[4];
+    char revision[4] = {0};
     esp_efuse_read_field_blob(ESP_EFUSE_USER_DATA_DOCK_HW_REV, &revision,
                               ESP_EFUSE_USER_DATA_DOCK_HW_REV[0]->bit_count);
     int rev = atoi(revision);
@@ -70,7 +70,7 @@ void board_init_revision(void) {
         s_charging_current_adc_unit = ADC_UNIT_1;
         s_charging_current_adc_ch = ADC_CHANNEL_5;
         // tied to IR side output on rev6+
-        s_ir_send_pin_int_top = GPIO_NUM_NC;
+        s_ir_send_pin_int_top = IR_SEND_PIN_INT_SIDE;
     }
 }
 
@@ -96,4 +96,12 @@ adc_unit_t board_get_charging_current_adc_unit(void) {
 
 adc_channel_t board_get_charging_current_adc_ch(void) {
     return s_charging_current_adc_ch;
+}
+
+bool board_is_switch_ext_inverted(void) {
+    return s_revision == 3 ? true : false;
+}
+
+gpio_mode_t board_switch_ext_gpio_mode(void) {
+    return s_revision == 3 ? GPIO_MODE_OUTPUT_OD : GPIO_MODE_OUTPUT;
 }

--- a/components/preferences/board.c
+++ b/components/preferences/board.c
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Unfolded Circle ApS and/or its affiliates <hello@unfoldedcircle.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "board.h"
+
+#include <ctype.h>
+#include <soc/efuse_reg.h>
+
+#include "esp_efuse.h"
+#include "esp_log.h"
+
+#include "efuse_user.h"
+
+static int s_revision = 4;
+// SPI chipselect for KSZ8851SNL ethernet ic, LOW -> enable communication to KSZ8851SNL
+// - r3: GPIO_NUM_6
+// - r4: GPIO_NUM_6
+// - r6: GPIO_NUM_14
+static gpio_num_t s_spi_cs_pin = GPIO_NUM_6;
+// INPUT, measures low side via 0.1 Ohm current to remote
+// - r3: GPIO_NUM_14
+// - r4: GPIO_NUM_14
+// - r6: GPIO_NUM_6
+static gpio_num_t s_charging_current_pin = GPIO_NUM_14;
+// GPIO pin of the internal top IR output
+// - r3: GPIO_NUM_7
+// - r4: GPIO_NUM_7, OUTPUT,OPEN DRAIN. physically pulled up to 2.4V
+// - r6: tied to IR side output
+static gpio_num_t s_ir_send_pin_int_top = GPIO_NUM_7;
+// Charger measurement ADC unit
+// - r3: ADC_UNIT_2
+// - r4: ADC_UNIT_2
+// - r6: ADC_UNIT_1
+static adc_unit_t s_charging_current_adc_unit = ADC_UNIT_2;
+// Charger measurement ADC channel
+// - r3: ADC_CHANNEL_3
+// - r4: ADC_CHANNEL_3
+// - r6: ADC_CHANNEL_5
+static adc_channel_t s_charging_current_adc_ch = ADC_CHANNEL_3;
+
+int read_efuse_revision() {
+    char revision[4];
+    esp_efuse_read_field_blob(ESP_EFUSE_USER_DATA_DOCK_HW_REV, &revision,
+                              ESP_EFUSE_USER_DATA_DOCK_HW_REV[0]->bit_count);
+    int rev = atoi(revision);
+    if (rev < 3 || rev > 6) {
+        ESP_LOGW("BOARD",
+                 "Invalid or no revision found in eFuse (%d): the device might not work properly! Using firmware "
+                 "revision: %s",
+                 rev, UCD_HW_REVISION_NAME);
+        return atoi(UCD_HW_REVISION_NAME);
+    }
+
+    ESP_LOGI("BOARD", "hw revision: %d, fw revision: %s", rev, UCD_HW_REVISION_NAME);
+    return rev;
+}
+
+void board_init_revision(void) {
+    s_revision = read_efuse_revision();
+
+    if (CONFIG_UCD_ETH_SPI_CS0_GPIO >= 0) {
+        s_spi_cs_pin = CONFIG_UCD_ETH_SPI_CS0_GPIO;
+    } else if (s_revision == 6) {
+        s_spi_cs_pin = GPIO_NUM_14;
+    }
+
+    if (s_revision == 6) {
+        s_charging_current_pin = GPIO_NUM_6;
+        s_charging_current_adc_unit = ADC_UNIT_1;
+        s_charging_current_adc_ch = ADC_CHANNEL_5;
+        // tied to IR side output on rev6+
+        s_ir_send_pin_int_top = GPIO_NUM_NC;
+    }
+}
+
+int board_get_revision(void) {
+    return s_revision;
+}
+
+gpio_num_t board_get_spi_cs(void) {
+    return s_spi_cs_pin;
+}
+
+gpio_num_t board_get_ir_send_pin_int_top(void) {
+    return s_ir_send_pin_int_top;
+}
+
+gpio_num_t board_get_charging_current_pin(void) {
+    return s_charging_current_pin;
+}
+
+adc_unit_t board_get_charging_current_adc_unit(void) {
+    return s_charging_current_adc_unit;
+}
+
+adc_channel_t board_get_charging_current_adc_ch(void) {
+    return s_charging_current_adc_ch;
+}

--- a/components/preferences/board.h
+++ b/components/preferences/board.h
@@ -8,7 +8,9 @@
 #pragma once
 
 #include "esp_bit_defs.h"
+#include "hal/adc_types.h"
 #include "soc/gpio_num.h"
+
 
 #include "sdkconfig.h"
 
@@ -38,7 +40,7 @@
 // 2. function: turnoff speaker amplifier when use as output low
 #define SCL                   GPIO_NUM_4    // OPEN DRAIN OUTPUT, physically pulled high
 #define SDA                   GPIO_NUM_5    // OPEN DRAIN OUTPUT, physically pulled high
-// SPI_CS and optional POE_SWITCH are defined per revision in board_r*.h.
+// optional POE_SWITCH is defined per revision in board_r*.h.
 
 #define I2S_BCLK              GPIO_NUM_8    // OUTPUT
 #define I2S_SPEAKER_DATA      GPIO_NUM_16   // OUTPUT
@@ -67,7 +69,6 @@
 #define SPI_INT               GPIO_NUM_46   // INPUT,  ETH_INT
 #define ROCKCHIP_PIN          GPIO_NUM_47   // to be determined, protected pin with BAT54S and 10k
 
-// CHARGING_CURRENT* are defined per revision in board_r*.h.
 #define RGB_LED               GPIO_NUM_15   // OUTPUT OPEN DRAIN, pulled physically to 5V 10k
 
 #define CHARGING_ENABLE       GPIO_NUM_45   // OUTPUT, physically pulled low
@@ -75,7 +76,7 @@
 #define IR_SEND_PIN_INT_SIDE  GPIO_NUM_38   // OUTPUT OPEN DRAIN, physicall pulled up 2.4v
 // IR_SEND_PIN_INT_SIDE is an inverted output: required for IRsend GPIO mask
 #define IR_SEND_PIN_INT_SIDE_INVERTED 1
-// IR_SEND_PIN_INT_TOP is defined per revision in board_r*.h.
+// IR_SEND_PIN_INT_TOP is defined with function board_get_ir_send_pin_int_top()
 // IR_SEND_PIN_INT_TOP is an inverted output: required for IRsend GPIO mask
 #define IR_SEND_PIN_INT_TOP_INVERTED  1
 
@@ -117,4 +118,34 @@
 #else
 #error You need to specify a board revision in the SDK configuration: \
 CONFIG_UCD_HW_REVISION_3, CONFIG_UCD_HW_REVISION_4, CONFIG_UCD_HW_REVISION_6
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Call this once during early startup to initialize all `board_get_*` getters from the hardware revision.
+void board_init_revision(void);
+
+// Return the board revision
+int board_get_revision(void);
+
+// SPI chipselect GPIO pin
+gpio_num_t board_get_spi_cs(void);
+
+// GPIO pin of the internal top IR output
+// @return pin or GPIO_NUM_NC if not used
+gpio_num_t board_get_ir_send_pin_int_top(void);
+
+// GPIO pin of the charger measurement
+gpio_num_t board_get_charging_current_pin(void);
+
+// Charger measurement ADC unit
+adc_unit_t    board_get_charging_current_adc_unit(void);
+
+// Charger measurement ADC channel
+adc_channel_t board_get_charging_current_adc_ch(void);
+
+#ifdef __cplusplus
+}
 #endif

--- a/components/preferences/board.h
+++ b/components/preferences/board.h
@@ -7,10 +7,10 @@
 
 #pragma once
 
+#include "driver/gpio.h"
 #include "esp_bit_defs.h"
 #include "hal/adc_types.h"
 #include "soc/gpio_num.h"
-
 
 #include "sdkconfig.h"
 
@@ -145,6 +145,12 @@ adc_unit_t    board_get_charging_current_adc_unit(void);
 
 // Charger measurement ADC channel
 adc_channel_t board_get_charging_current_adc_ch(void);
+
+// Inverted output or not for SWITCH_EXT_1 & SWITCH_EXT_2
+bool board_is_switch_ext_inverted(void);
+
+// GPIO output mode for SWITCH_EXT_1 & SWITCH_EXT_2: open drain or floating
+gpio_mode_t board_switch_ext_gpio_mode(void);
 
 #ifdef __cplusplus
 }

--- a/components/preferences/board.h
+++ b/components/preferences/board.h
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include "driver/gpio.h"
 #include "esp_bit_defs.h"
 #include "hal/adc_types.h"
+#include "hal/gpio_types.h"
 #include "soc/gpio_num.h"
 
 #include "sdkconfig.h"

--- a/components/preferences/board_r3.h
+++ b/components/preferences/board_r3.h
@@ -9,8 +9,3 @@
 
 #define UCD_HW_MODEL_NAME "UCD3"
 #define UCD_HW_REVISION_NAME "3"
-
-// Inverted output or not for SWITCH_EXT_1 & SWITCH_EXT_2
-#define SWITCH_EXT_INVERTED 1
-// GPIO output mode for SWITCH_EXT_1 & SWITCH_EXT_2: open drain or floating
-#define SWITCH_EXT_GPIO_MODE GPIO_MODE_OUTPUT_OD

--- a/components/preferences/board_r3.h
+++ b/components/preferences/board_r3.h
@@ -10,17 +10,6 @@
 #define UCD_HW_MODEL_NAME "UCD3"
 #define UCD_HW_REVISION_NAME "3"
 
-// chipselect for W5500 ethernet ic, LOW -> enable communication to w5500
-#define SPI_CS GPIO_NUM_6
-
-// INPUT, measures low side via 0.1 Ohm current to remote
-#define CHARGING_CURRENT GPIO_NUM_14
-#define CHARGING_CURRENT_ADC_UNIT ADC_UNIT_2
-#define CHARGING_CURRENT_ADC_CH ADC_CHANNEL_3
-
-// OUTPUT,OPEN DRAIN. physically pulled up to 2.4V
-#define IR_SEND_PIN_INT_TOP GPIO_NUM_7
-
 // Inverted output or not for SWITCH_EXT_1 & SWITCH_EXT_2
 #define SWITCH_EXT_INVERTED 1
 // GPIO output mode for SWITCH_EXT_1 & SWITCH_EXT_2: open drain or floating

--- a/components/preferences/board_r4.h
+++ b/components/preferences/board_r4.h
@@ -10,17 +10,6 @@
 #define UCD_HW_MODEL_NAME "UCD3"
 #define UCD_HW_REVISION_NAME "4"
 
-// chipselect for KSZ8851SNL ethernet ic, LOW -> enable communication to KSZ8851SNL
-#define SPI_CS GPIO_NUM_6
-
-// INPUT, measures low side via 0.1 Ohm current to remote
-#define CHARGING_CURRENT GPIO_NUM_14
-#define CHARGING_CURRENT_ADC_UNIT ADC_UNIT_2
-#define CHARGING_CURRENT_ADC_CH ADC_CHANNEL_3
-
-// OUTPUT,OPEN DRAIN. physically pulled up to 2.4V
-#define IR_SEND_PIN_INT_TOP GPIO_NUM_7
-
 // Inverted output or not for SWITCH_EXT_1 & SWITCH_EXT_2
 #define SWITCH_EXT_INVERTED 0
 // GPIO output mode for SWITCH_EXT_1 & SWITCH_EXT_2: open drain or floating

--- a/components/preferences/board_r4.h
+++ b/components/preferences/board_r4.h
@@ -9,8 +9,3 @@
 
 #define UCD_HW_MODEL_NAME "UCD3"
 #define UCD_HW_REVISION_NAME "4"
-
-// Inverted output or not for SWITCH_EXT_1 & SWITCH_EXT_2
-#define SWITCH_EXT_INVERTED 0
-// GPIO output mode for SWITCH_EXT_1 & SWITCH_EXT_2: open drain or floating
-#define SWITCH_EXT_GPIO_MODE GPIO_MODE_OUTPUT

--- a/components/preferences/board_r6.h
+++ b/components/preferences/board_r6.h
@@ -12,8 +12,3 @@
 
 // OUTPUT, PoE voltage switch (rev6+). Not used yet
 #define POE_SWITCH GPIO_NUM_7
-
-// Inverted output or not for SWITCH_EXT_1 & SWITCH_EXT_2
-#define SWITCH_EXT_INVERTED 0
-// GPIO output mode for SWITCH_EXT_1 & SWITCH_EXT_2: open drain or floating
-#define SWITCH_EXT_GPIO_MODE GPIO_MODE_OUTPUT

--- a/components/preferences/board_r6.h
+++ b/components/preferences/board_r6.h
@@ -10,18 +10,8 @@
 #define UCD_HW_MODEL_NAME "UCD3"
 #define UCD_HW_REVISION_NAME "6"
 
-// chipselect for KSZ8851SNL ethernet ic, LOW -> enable communication to KSZ8851SNL
-#define SPI_CS GPIO_NUM_14
-// OUTPUT, PoE voltage switch (rev6+)
+// OUTPUT, PoE voltage switch (rev6+). Not used yet
 #define POE_SWITCH GPIO_NUM_7
-
-// INPUT, measures low side via 0.1 Ohm current to remote
-#define CHARGING_CURRENT GPIO_NUM_6
-#define CHARGING_CURRENT_ADC_UNIT ADC_UNIT_1
-#define CHARGING_CURRENT_ADC_CH ADC_CHANNEL_5
-
-// tied to IR side output on rev6+
-#define IR_SEND_PIN_INT_TOP IR_SEND_PIN_INT_SIDE
 
 // Inverted output or not for SWITCH_EXT_1 & SWITCH_EXT_2
 #define SWITCH_EXT_INVERTED 0

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -205,21 +205,21 @@ void init_gpios(void) {
     gpio_set_level(TX1, TX_INVERTED);  // output low
 
     // RS232 / IR out 1
-    gpio_init(SWITCH_EXT_1, SWITCH_EXT_GPIO_MODE, GPIO_PULLUP_DISABLE);
+    gpio_init(SWITCH_EXT_1, board_switch_ext_gpio_mode(), GPIO_PULLUP_DISABLE);
     gpio_init(MEASURE_GND_1, GPIO_MODE_INPUT, GPIO_PULLUP_DISABLE);
     // also use input to retrieve current state in trigger output mode
     gpio_init(SWITCH_GND_1, GPIO_MODE_INPUT_OUTPUT, GPIO_PULLUP_DISABLE, GPIO_PULLDOWN_ENABLE);
     // disable 5V & GND
-    gpio_set_level(SWITCH_EXT_1, SWITCH_EXT_INVERTED);  // output low
-    gpio_set_level(SWITCH_GND_1, 0);                    // output low
+    gpio_set_level(SWITCH_EXT_1, board_is_switch_ext_inverted() ? 1 : 0);  // output low
+    gpio_set_level(SWITCH_GND_1, 0);                                       // output low
 
     // RS232 / IR out 2
-    gpio_init(SWITCH_EXT_2, SWITCH_EXT_GPIO_MODE, GPIO_PULLUP_DISABLE);
+    gpio_init(SWITCH_EXT_2, board_switch_ext_gpio_mode(), GPIO_PULLUP_DISABLE);
     gpio_init(MEASURE_GND_2, GPIO_MODE_INPUT, GPIO_PULLUP_DISABLE);
     // also use input to retrieve current state in trigger output mode
     gpio_init(SWITCH_GND_2, GPIO_MODE_INPUT_OUTPUT, GPIO_PULLUP_DISABLE, GPIO_PULLDOWN_ENABLE);
     // disable 5V & GND
-    gpio_set_level(SWITCH_EXT_2, SWITCH_EXT_INVERTED);
+    gpio_set_level(SWITCH_EXT_2, board_is_switch_ext_inverted() ? 1 : 0);
     gpio_set_level(SWITCH_GND_2, 0);
 }
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -23,6 +23,7 @@
 #include "charger.h"
 #include "config.h"
 #include "display.h"
+#include "efuse.h"
 #include "external_port.h"
 #include "frogfs/frogfs.h"
 #include "frogfs/vfs.h"
@@ -174,7 +175,7 @@ void init_gpios(void) {
         ESP_LOGE(TAG, "Failed to initialize ETH PWM LED: %d", ret);
     }
 
-    gpio_init(CHARGING_CURRENT, GPIO_MODE_INPUT);
+    gpio_init(board_get_charging_current_pin(), GPIO_MODE_INPUT);
     // also input to be able to read current state in charger monitor
     gpio_init(CHARGING_ENABLE, GPIO_MODE_INPUT_OUTPUT, GPIO_PULLUP_DISABLE);
     gpio_set_level(CHARGING_ENABLE, 0);
@@ -187,10 +188,13 @@ void init_gpios(void) {
     // internal IR
     gpio_init(IR_RECEIVE_PIN, GPIO_MODE_INPUT);
 
-    gpio_init(IR_SEND_PIN_INT_TOP, GPIO_MODE_OUTPUT_OD, GPIO_PULLUP_DISABLE);
     gpio_init(IR_SEND_PIN_INT_SIDE, GPIO_MODE_OUTPUT_OD, GPIO_PULLUP_DISABLE);
-    gpio_set_level(IR_SEND_PIN_INT_TOP, IR_SEND_PIN_INT_TOP_INVERTED);    // output low (inverted logic)
     gpio_set_level(IR_SEND_PIN_INT_SIDE, IR_SEND_PIN_INT_SIDE_INVERTED);  // output low (inverted logic)
+    gpio_num_t ir_send_pin_int_top = board_get_ir_send_pin_int_top();
+    if (ir_send_pin_int_top != GPIO_NUM_NC) {
+        gpio_init(ir_send_pin_int_top, GPIO_MODE_OUTPUT_OD, GPIO_PULLUP_DISABLE);
+        gpio_set_level(ir_send_pin_int_top, IR_SEND_PIN_INT_TOP_INVERTED);  // output low (inverted logic)
+    }
 
     // configure UART out for IR blaster
     gpio_init(TX0, GPIO_MODE_OUTPUT_OD);
@@ -293,16 +297,16 @@ esp_err_t init_charger(std::shared_ptr<AdcChannel> vcc_channel, std::shared_ptr<
     assert(vcc_channel);
     assert(shared_adc_unit);
 
-    adc_unit_t unit = CHARGING_CURRENT_ADC_UNIT;
-    auto       adc_ch = CHARGING_CURRENT_ADC_CH;
+    adc_unit_t    unit = board_get_charging_current_adc_unit();
+    adc_channel_t adc_ch = board_get_charging_current_adc_ch();
 
     std::shared_ptr<AdcUnit> adcUnit;
-#if defined(CONFIG_UCD_HW_REVISION_6)
-    // Rev6 shares ADC_UNIT_1 between charger current and port sensing.
-    adcUnit = shared_adc_unit;
-#else
-    adcUnit = AdcUnit::create(unit);
-#endif
+    if (board_get_revision() == 6) {
+        // Rev6 shares ADC_UNIT_1 between charger current and port sensing.
+        adcUnit = shared_adc_unit;
+    } else {
+        adcUnit = AdcUnit::create(unit);
+    }
     ESP_RETURN_ON_FALSE(adcUnit, ESP_FAIL, TAG, "Cannot initialize charger: ADC unit %d creation failed", unit);
 
     std::unique_ptr<AdcChannel> channel = adcUnit->createChannel(adc_ch, ADC_ATTEN_DB_0);
@@ -319,6 +323,9 @@ static void factoryResetHandler(void *arg, esp_event_base_t event_base, int32_t 
 
 extern "C" void app_main(void) {
     esp_err_t ret = ESP_OK;
+
+    board_init_revision();
+
     init_gpios();
 
     // to set another timezone

--- a/test/mocks/hal/adc_types.h
+++ b/test/mocks/hal/adc_types.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: 2020-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "soc/soc_caps.h"
+#include "soc/clk_tree_defs.h"
+// #include "esp_attr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief ADC unit
+ */
+typedef enum {
+    ADC_UNIT_1,        ///< SAR ADC 1
+    ADC_UNIT_2,        ///< SAR ADC 2
+} adc_unit_t;
+
+/**
+ * @brief ADC channels
+ */
+typedef enum {
+    ADC_CHANNEL_0,     ///< ADC channel
+    ADC_CHANNEL_1,     ///< ADC channel
+    ADC_CHANNEL_2,     ///< ADC channel
+    ADC_CHANNEL_3,     ///< ADC channel
+    ADC_CHANNEL_4,     ///< ADC channel
+    ADC_CHANNEL_5,     ///< ADC channel
+    ADC_CHANNEL_6,     ///< ADC channel
+    ADC_CHANNEL_7,     ///< ADC channel
+    ADC_CHANNEL_8,     ///< ADC channel
+    ADC_CHANNEL_9,     ///< ADC channel
+    ADC_CHANNEL_10,    ///< ADC channel
+} adc_channel_t;
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/mocks/hal/gpio_types.h
+++ b/test/mocks/hal/gpio_types.h
@@ -1,0 +1,175 @@
+/*
+ * SPDX-FileCopyrightText: 2015-2026 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "soc/soc_caps.h"
+#include "soc/gpio_num.h"
+#include "esp_bit_defs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define GPIO_PIN_COUNT                          (SOC_GPIO_PIN_COUNT)
+/// Check whether it is a valid GPIO number
+#define GPIO_IS_VALID_GPIO(gpio_num)            ((gpio_num >= 0) && (gpio_num < SOC_GPIO_PIN_COUNT) && \
+                                                 (((1ULL << (gpio_num)) & SOC_GPIO_VALID_GPIO_MASK) != 0))
+/// Check whether it can be a valid GPIO number of output mode
+#define GPIO_IS_VALID_OUTPUT_GPIO(gpio_num)     ((gpio_num >= 0) && (gpio_num < SOC_GPIO_PIN_COUNT) && \
+                                                 (((1ULL << (gpio_num)) & SOC_GPIO_VALID_OUTPUT_GPIO_MASK) != 0))
+/// Check whether it can be a valid digital I/O pad
+#define GPIO_IS_VALID_DIGITAL_IO_PAD(gpio_num)  ((gpio_num >= 0) && (gpio_num < SOC_GPIO_PIN_COUNT) && \
+                                                 (((1ULL << (gpio_num)) & SOC_GPIO_VALID_DIGITAL_IO_PAD_MASK) != 0))
+
+typedef enum {
+    GPIO_PORT_0 = 0,
+    GPIO_PORT_MAX,
+} gpio_port_t;
+
+#define GPIO_PIN_REG_0          IO_MUX_GPIO0_REG
+#define GPIO_PIN_REG_1          IO_MUX_GPIO1_REG
+#define GPIO_PIN_REG_2          IO_MUX_GPIO2_REG
+#define GPIO_PIN_REG_3          IO_MUX_GPIO3_REG
+#define GPIO_PIN_REG_4          IO_MUX_GPIO4_REG
+#define GPIO_PIN_REG_5          IO_MUX_GPIO5_REG
+#define GPIO_PIN_REG_6          IO_MUX_GPIO6_REG
+#define GPIO_PIN_REG_7          IO_MUX_GPIO7_REG
+#define GPIO_PIN_REG_8          IO_MUX_GPIO8_REG
+#define GPIO_PIN_REG_9          IO_MUX_GPIO9_REG
+#define GPIO_PIN_REG_10          IO_MUX_GPIO10_REG
+#define GPIO_PIN_REG_11          IO_MUX_GPIO11_REG
+#define GPIO_PIN_REG_12          IO_MUX_GPIO12_REG
+#define GPIO_PIN_REG_13          IO_MUX_GPIO13_REG
+#define GPIO_PIN_REG_14          IO_MUX_GPIO14_REG
+#define GPIO_PIN_REG_15          IO_MUX_GPIO15_REG
+#define GPIO_PIN_REG_16          IO_MUX_GPIO16_REG
+#define GPIO_PIN_REG_17          IO_MUX_GPIO17_REG
+#define GPIO_PIN_REG_18          IO_MUX_GPIO18_REG
+#define GPIO_PIN_REG_19          IO_MUX_GPIO19_REG
+#define GPIO_PIN_REG_20          IO_MUX_GPIO20_REG
+#define GPIO_PIN_REG_21          IO_MUX_GPIO21_REG
+#define GPIO_PIN_REG_22          IO_MUX_GPIO22_REG
+#define GPIO_PIN_REG_23          IO_MUX_GPIO23_REG
+#define GPIO_PIN_REG_24          IO_MUX_GPIO24_REG
+#define GPIO_PIN_REG_25          IO_MUX_GPIO25_REG
+#define GPIO_PIN_REG_26          IO_MUX_GPIO26_REG
+#define GPIO_PIN_REG_27          IO_MUX_GPIO27_REG
+#define GPIO_PIN_REG_28          IO_MUX_GPIO28_REG
+#define GPIO_PIN_REG_29          IO_MUX_GPIO29_REG
+#define GPIO_PIN_REG_30          IO_MUX_GPIO30_REG
+#define GPIO_PIN_REG_31          IO_MUX_GPIO31_REG
+#define GPIO_PIN_REG_32          IO_MUX_GPIO32_REG
+#define GPIO_PIN_REG_33          IO_MUX_GPIO33_REG
+#define GPIO_PIN_REG_34          IO_MUX_GPIO34_REG
+#define GPIO_PIN_REG_35          IO_MUX_GPIO35_REG
+#define GPIO_PIN_REG_36          IO_MUX_GPIO36_REG
+#define GPIO_PIN_REG_37          IO_MUX_GPIO37_REG
+#define GPIO_PIN_REG_38          IO_MUX_GPIO38_REG
+#define GPIO_PIN_REG_39          IO_MUX_GPIO39_REG
+#define GPIO_PIN_REG_40          IO_MUX_GPIO40_REG
+#define GPIO_PIN_REG_41          IO_MUX_GPIO41_REG
+#define GPIO_PIN_REG_42          IO_MUX_GPIO42_REG
+#define GPIO_PIN_REG_43          IO_MUX_GPIO43_REG
+#define GPIO_PIN_REG_44          IO_MUX_GPIO44_REG
+#define GPIO_PIN_REG_45          IO_MUX_GPIO45_REG
+#define GPIO_PIN_REG_46          IO_MUX_GPIO46_REG
+#define GPIO_PIN_REG_47          IO_MUX_GPIO47_REG
+#define GPIO_PIN_REG_48          IO_MUX_GPIO48_REG
+#define GPIO_PIN_REG_49          IO_MUX_GPIO49_REG
+#define GPIO_PIN_REG_50          IO_MUX_GPIO50_REG
+#define GPIO_PIN_REG_51          IO_MUX_GPIO51_REG
+#define GPIO_PIN_REG_52          IO_MUX_GPIO52_REG
+#define GPIO_PIN_REG_53          IO_MUX_GPIO53_REG
+#define GPIO_PIN_REG_54          IO_MUX_GPIO54_REG
+
+typedef enum {
+    GPIO_INTR_DISABLE = 0,     /*!< Disable GPIO interrupt                             */
+    GPIO_INTR_POSEDGE = 1,     /*!< GPIO interrupt type : rising edge                  */
+    GPIO_INTR_NEGEDGE = 2,     /*!< GPIO interrupt type : falling edge                 */
+    GPIO_INTR_ANYEDGE = 3,     /*!< GPIO interrupt type : both rising and falling edge */
+    GPIO_INTR_LOW_LEVEL = 4,   /*!< GPIO interrupt type : input low level trigger      */
+    GPIO_INTR_HIGH_LEVEL = 5,  /*!< GPIO interrupt type : input high level trigger     */
+    GPIO_INTR_MAX,
+} gpio_int_type_t;
+
+/** @cond */
+#define GPIO_MODE_DEF_DISABLE         (0)
+#define GPIO_MODE_DEF_INPUT           (BIT0)    ///< bit mask for input
+#define GPIO_MODE_DEF_OUTPUT          (BIT1)    ///< bit mask for output
+#define GPIO_MODE_DEF_OD              (BIT2)    ///< bit mask for OD mode
+/** @endcond */
+
+typedef enum {
+    GPIO_MODE_DISABLE = GPIO_MODE_DEF_DISABLE,                                                         /*!< GPIO mode : disable input and output             */
+    GPIO_MODE_INPUT = GPIO_MODE_DEF_INPUT,                                                             /*!< GPIO mode : input only                           */
+    GPIO_MODE_OUTPUT = GPIO_MODE_DEF_OUTPUT,                                                           /*!< GPIO mode : output only mode                     */
+    GPIO_MODE_OUTPUT_OD = ((GPIO_MODE_DEF_OUTPUT) | (GPIO_MODE_DEF_OD)),                               /*!< GPIO mode : output only with open-drain mode     */
+    GPIO_MODE_INPUT_OUTPUT_OD = ((GPIO_MODE_DEF_INPUT) | (GPIO_MODE_DEF_OUTPUT) | (GPIO_MODE_DEF_OD)), /*!< GPIO mode : output and input with open-drain mode*/
+    GPIO_MODE_INPUT_OUTPUT = ((GPIO_MODE_DEF_INPUT) | (GPIO_MODE_DEF_OUTPUT)),                         /*!< GPIO mode : output and input mode                */
+} gpio_mode_t;
+
+typedef enum {
+    GPIO_PULLUP_DISABLE = 0x0,     /*!< Disable GPIO pull-up resistor */
+    GPIO_PULLUP_ENABLE = 0x1,      /*!< Enable GPIO pull-up resistor */
+} gpio_pullup_t;
+
+typedef enum {
+    GPIO_PULLDOWN_DISABLE = 0x0,   /*!< Disable GPIO pull-down resistor */
+    GPIO_PULLDOWN_ENABLE = 0x1,    /*!< Enable GPIO pull-down resistor  */
+} gpio_pulldown_t;
+
+typedef enum {
+    GPIO_PULLUP_ONLY,               /*!< Pad pull up            */
+    GPIO_PULLDOWN_ONLY,             /*!< Pad pull down          */
+    GPIO_PULLUP_PULLDOWN,           /*!< Pad pull up + pull down*/
+    GPIO_FLOATING,                  /*!< Pad floating           */
+} gpio_pull_mode_t;
+
+typedef enum {
+    GPIO_DRIVE_CAP_0       = 0,    /*!< Pad drive capability: weak          */
+    GPIO_DRIVE_CAP_1       = 1,    /*!< Pad drive capability: stronger      */
+    GPIO_DRIVE_CAP_2       = 2,    /*!< Pad drive capability: medium */
+    GPIO_DRIVE_CAP_DEFAULT = 2,    /*!< Pad drive capability: medium */
+    GPIO_DRIVE_CAP_3       = 3,    /*!< Pad drive capability: strongest     */
+    GPIO_DRIVE_CAP_MAX,
+} gpio_drive_cap_t;
+
+#if SOC_GPIO_SUPPORT_PIN_HYS_FILTER
+/**
+ * @brief Available option for configuring hysteresis feature of GPIOs
+ */
+typedef enum {
+#if SOC_GPIO_SUPPORT_PIN_HYS_CTRL_BY_EFUSE
+    GPIO_HYS_CTRL_EFUSE     = 0,    /*!< Pad input hysteresis ctrl by efuse */
+#endif
+    GPIO_HYS_SOFT_DISABLE,          /*!< Pad input hysteresis disable by software */
+    GPIO_HYS_SOFT_ENABLE,           /*!< Pad input hysteresis enable by software */
+} gpio_hys_ctrl_mode_t;
+#endif
+
+/**
+ * @brief Structure that contains the configuration of an IO
+ */
+typedef struct {
+    gpio_drive_cap_t drv;             /*!< Value of drive strength */
+    uint32_t fun_sel             : 8; /*!< Value of IOMUX function selection */
+    uint32_t sig_out             : 16;/*!< Index of the outputting peripheral signal */
+    uint32_t pu                  : 1; /*!< Status of pull-up enabled or not */
+    uint32_t pd                  : 1; /*!< Status of pull-down enabled or not */
+    uint32_t ie                  : 1; /*!< Status of input enabled or not */
+    uint32_t oe                  : 1; /*!< Status of output enabled or not */
+    uint32_t oe_ctrl_by_periph   : 1; /*!< True if use output enable signal from peripheral, otherwise False */
+    uint32_t oe_inv              : 1; /*!< Whether the output enable signal is inversed or not */
+    uint32_t od                  : 1; /*!< Status of open-drain enabled or not */
+    uint32_t slp_sel             : 1; /*!< Status of pin sleep mode enabled or not */
+} gpio_io_config_t;
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This PR unifies the firmware builds for hardware revisions 4 and 6 into a single binary. The hardware revision is now detected at runtime via eFuses, and the system dynamically configures GPIOs and ADC settings based on the detected version. This ensures a single firmware image can support multiple board iterations.
If the eFuses don't contain a valid revision number, the compiled-in revision number is used as fallback.

Changes:
- Runtime Revision Detection: Added `board_init_revision()` to read the hardware revision from eFuses BLK3 during early startup.
- Dynamic Hardware Abstraction: Replaced compile-time macros e.g., `CHARGING_CURRENT_PIN` with dynamic getter functions in `board.h` and `board.c`.
- GPIO & ADC Mapping:
  - Implemented logic in `board.c` to handle differences in SPI Chip Select, charging current measurement pins, and ADC units/channels between Rev 4 and Rev 6

Cleanup:
- Removed redundant GPIO and ADC macros from `board_r3.h`, `board_r4.h`, and `board_r6.h`.
- Updated `main.cpp` and external_port.cpp to use the new dynamic `board_get_*` and `board_is_*` functions.
- Testing: Added HAL mocks `gpio_types.h`, `adc_types.h` to support unit testing of the new board configuration logic.

Note: the old internal revision 3 board has been included too, but this revision also requires Kconfig changes for the different ethernet chip.