### PR TITLE
Clean up and linting fixes

### DIFF
--- a/components/adc/adc_unit.cpp
+++ b/components/adc/adc_unit.cpp
@@ -84,9 +84,7 @@ bool AdcUnit::calibrationInit(adc_unit_t unit, adc_channel_t channel, adc_atten_
             calibrated = true;
         }
     }
-#endif
-
-#if ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
+#elif ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
     if (!calibrated) {
         ESP_LOGI(TAG, "Calibration scheme version is Line Fitting");
         adc_cali_line_fitting_config_t cali_config = {

--- a/components/infrared/service_ir.cpp
+++ b/components/infrared/service_ir.cpp
@@ -732,4 +732,4 @@ InfraredService &InfraredService::getInstance() {
     return instance;
 }
 
-InfraredService &irService = irService.getInstance();
+InfraredService &irService = InfraredService::getInstance();

--- a/main/button.cpp
+++ b/main/button.cpp
@@ -66,7 +66,7 @@ esp_err_t init_button() {
     button_handle_t gpio_btn = iot_button_create(&gpio_btn_cfg);
     ESP_RETURN_ON_FALSE(gpio_btn, ESP_FAIL, TAG, "Button create failed");
     int32_t duration = 2000;
-    iot_button_set_param(gpio_btn, BUTTON_LONG_PRESS_TIME_MS, (void *)duration);
+    iot_button_set_param(gpio_btn, BUTTON_LONG_PRESS_TIME_MS, (void *)(intptr_t)duration);
 
     ESP_RETURN_ON_ERROR(iot_button_register_cb(gpio_btn, BUTTON_SINGLE_CLICK, button_single_click_cb, NULL), TAG,
                         "Error registering button single click handler");


### PR DESCRIPTION
- `iot_button_set_param` uses an "old-school" untyped parameter with `void *`: cast to `intptr_t` as it is also done within the button library to avoid compiler warning.
- `InfraredService` creation used the static variable, which is confusing: use proper `InfraredService::getInstance();` initialization.
- ADC calibration had a potential fallback init if both calibration schemas were supported: use the same exclusive selection in `calibrationInit` as in `calibrationDeinit`.