### PR TITLE
Add TCP/RS232 serial bridge with WebSocket API integration

### DIFF
--- a/components/common/string_util.cpp
+++ b/components/common/string_util.cpp
@@ -75,3 +75,20 @@ std::string trim_copy(std::string s) {
     trim(s);
     return s;
 }
+
+size_t latin1_to_utf8(const uint8_t *in, size_t in_len, char *out, size_t out_size) {
+    size_t j = 0;
+    for (size_t i = 0; i < in_len && j < out_size - 1; i++) {
+        uint8_t c = in[i];
+        if (c < 0x80) {
+            out[j++] = c;
+        } else {
+            // 0x80-0xFF → 2-byte UTF-8
+            if (j + 1 >= out_size - 1) break;
+            out[j++] = 0xC0 | (c >> 6);
+            out[j++] = 0x80 | (c & 0x3F);
+        }
+    }
+    out[j] = '\0';
+    return j;
+}

--- a/components/common/string_util.h
+++ b/components/common/string_util.h
@@ -45,3 +45,8 @@ std::string rtrim_copy(std::string s);
 
 // Trim from both ends (copying)
 std::string trim_copy(std::string s);
+
+/// Convert Latin-1 (ISO-8859-1) bytes to a valid UTF-8 string.
+/// Worst case output size: 2 * input size.
+/// @return number of bytes written to out (without null terminator)
+size_t latin1_to_utf8(const uint8_t *in, size_t in_len, char *out, size_t out_size);

--- a/components/external_port/external_port.cpp
+++ b/components/external_port/external_port.cpp
@@ -103,8 +103,8 @@ static bool match_signature(const port_signature_t *sig, size_t count, const int
     return true;
 }
 
-// TODO static or dynamic config option?
-#define CONFIG_PORT_UART_RING_BUFFER_SIZE 512
+#define CONFIG_PORT_UART_RX_BUFFER_SIZE 2048
+#define CONFIG_PORT_UART_TX_BUFFER_SIZE 512
 
 ExternalPort::ExternalPort(uint8_t port, ext_port_config_t config, std::unique_ptr<AdcReader> reader,
                            std::shared_ptr<AdcReader> vcc_reader)
@@ -468,7 +468,7 @@ esp_err_t ExternalPort::initUart() {
     intr_alloc_flags = ESP_INTR_FLAG_IRAM;
 #endif
     ESP_GOTO_ON_ERROR(
-        uart_driver_install(config_.uart_port, CONFIG_PORT_UART_RING_BUFFER_SIZE, CONFIG_PORT_UART_RING_BUFFER_SIZE,
+        uart_driver_install(config_.uart_port, CONFIG_PORT_UART_RX_BUFFER_SIZE, CONFIG_PORT_UART_TX_BUFFER_SIZE,
                             event_queue_size, &uart_event_queue_, intr_alloc_flags),
         err_uart_install, tag_, "install uart driver failed");
     ESP_GOTO_ON_ERROR(uart_param_config(config_.uart_port, &uart_config), err_uart_config, tag_,

--- a/components/external_port/external_port.h
+++ b/components/external_port/external_port.h
@@ -57,6 +57,12 @@ class ExternalPort {
     /// @brief Get the current operation mode of the external port.
     ExtPortMode getMode() { return mode_; };
 
+    /// @brief Get the UART event queue handle (for serial bridge integration).
+    QueueHandle_t getUartEventQueue() const { return uart_event_queue_; }
+
+    /// @brief Get the UART port number.
+    uart_port_t getUartPort() const { return config_.uart_port; }
+
     /// @brief Check if the current mode supports IR sending.
     /// @return true if IR can be sent, false otherwise.
     bool supportsIR();

--- a/components/preferences/config.cpp
+++ b/components/preferences/config.cpp
@@ -114,13 +114,7 @@ bool Config::setWifi(std::string ssid, std::string password) {
 }
 
 bool Config::setLogLevel(UCLog::Level level) {
-    if (!m_preferences.begin(m_prefGeneral, false)) {
-        return false;
-    }
-    m_preferences.putUShort("log_level", level);
-
-    m_preferences.end();
-    return true;
+    return setUShortSetting(m_prefGeneral, "log_level", static_cast<uint16_t>(level));
 }
 
 bool Config::setSyslogServer(const std::string& server, uint16_t port) {
@@ -142,13 +136,7 @@ bool Config::setSyslogServer(const std::string& server, uint16_t port) {
 }
 
 bool Config::enableSyslog(bool enable) {
-    if (!m_preferences.begin(m_prefGeneral, false)) {
-        return false;
-    }
-    m_preferences.putBool("syslog_enabled", enable);
-
-    m_preferences.end();
-    return true;
+    return setBoolSetting(m_prefGeneral, "syslog_enabled", enable);
 }
 
 bool Config::getTestMode() {
@@ -156,13 +144,7 @@ bool Config::getTestMode() {
 }
 
 bool Config::setTestMode(bool enable) {
-    if (!m_preferences.begin(m_prefGeneral, false)) {
-        return false;
-    }
-    m_preferences.putBool("testmode", enable);
-
-    m_preferences.end();
-    return true;
+    return setBoolSetting(m_prefGeneral, "testmode", enable);
 }
 
 std::string Config::getToken() {
@@ -235,13 +217,7 @@ std::string Config::getSoftwareVersion() {
 }
 
 bool Config::enableNtp(bool enable) {
-    if (!m_preferences.begin(m_prefGeneral, false)) {
-        return false;
-    }
-    m_preferences.putBool("ntp_enabled", enable);
-
-    m_preferences.end();
-    return true;
+    return setBoolSetting(m_prefGeneral, "ntp_enabled", enable);
 }
 
 bool Config::isNtpEnabled() {
@@ -326,9 +302,7 @@ uint8_t Config::getVolume() {
 }
 
 void Config::setVolume(uint8_t volume) {
-    m_preferences.begin(m_prefGeneral, false);
-    m_preferences.putUChar("volume", volume);
-    m_preferences.end();
+    setUCharSetting(m_prefGeneral, "volume", volume);
 }
 
 ExtPortMode Config::getExternalPortMode(uint8_t port) {
@@ -345,13 +319,7 @@ ExtPortMode Config::getExternalPortMode(uint8_t port) {
 bool Config::setExternalPortMode(uint8_t port, ExtPortMode mode) {
     char keyname[8];
     snprintf(keyname, sizeof(keyname), "port%u", port);
-    if (!m_preferences.begin(m_prefGeneral, false)) {
-        return false;
-    }
-    m_preferences.putUChar(keyname, mode);
-
-    m_preferences.end();
-    return true;
+    return setUCharSetting(m_prefGeneral, keyname, static_cast<uint8_t>(mode));
 }
 
 std::string Config::getExternalPortUart(uint8_t port) {
@@ -381,12 +349,7 @@ bool Config::setIrSendCore(uint16_t core) {
     if (core > 1) {
         core = 1;
     }
-    if (!m_preferences.begin(m_prefGeneral, false)) {
-        return false;
-    }
-    m_preferences.putUShort("irsend_core", core);
-    m_preferences.end();
-    return true;
+    return setUShortSetting(m_prefGeneral, "irsend_core", core);
 }
 
 uint16_t Config::getIrSendPriority() {
@@ -397,12 +360,7 @@ bool Config::setIrSendPriority(uint16_t priority) {
     if (priority >= configMAX_PRIORITIES) {
         priority = configMAX_PRIORITIES - 1;
     }
-    if (!m_preferences.begin(m_prefGeneral, false)) {
-        return false;
-    }
-    m_preferences.putUShort("irsend_prio", priority);
-    m_preferences.end();
-    return true;
+    return setUShortSetting(m_prefGeneral, "irsend_prio", priority);
 }
 
 uint16_t Config::getIrLearnCore() {
@@ -413,12 +371,7 @@ bool Config::setIrLearnCore(uint16_t core) {
     if (core > 1) {
         core = 1;
     }
-    if (!m_preferences.begin(m_prefGeneral, false)) {
-        return false;
-    }
-    m_preferences.putUShort("irlearn_core", core);
-    m_preferences.end();
-    return true;
+    return setUShortSetting(m_prefGeneral, "irlearn_core", core);
 }
 
 uint16_t Config::getIrLearnPriority() {
@@ -429,22 +382,11 @@ bool Config::setIrLearnPriority(uint16_t priority) {
     if (priority >= configMAX_PRIORITIES) {
         priority = configMAX_PRIORITIES - 1;
     }
-    if (!m_preferences.begin(m_prefGeneral, false)) {
-        return false;
-    }
-    m_preferences.putUShort("irlearn_prio", priority);
-    m_preferences.end();
-    return true;
+    return setUShortSetting(m_prefGeneral, "irlearn_prio", priority);
 }
 
 bool Config::enableGcServer(bool enable) {
-    if (!m_preferences.begin(m_prefGeneral, false)) {
-        return false;
-    }
-    m_preferences.putBool("gc_srv", enable);
-
-    m_preferences.end();
-    return true;
+    return setBoolSetting(m_prefGeneral, "gc_srv", enable);
 }
 
 bool Config::isGcServerEnabled() {
@@ -452,17 +394,67 @@ bool Config::isGcServerEnabled() {
 }
 
 bool Config::enableGcServerBeacon(bool enable) {
-    if (!m_preferences.begin(m_prefGeneral, false)) {
-        return false;
-    }
-    m_preferences.putBool("gc_amxb", enable);
-
-    m_preferences.end();
-    return true;
+    return setBoolSetting(m_prefGeneral, "gc_amxb", enable);
 }
 
 bool Config::isGcServerBeaconEnabled() {
     return getBoolSetting(m_prefGeneral, "gc_amxb", false);
+}
+
+bool Config::enableSerialTcp(bool enable) {
+    return setBoolSetting(m_prefGeneral, "serial_tcp", enable);
+}
+
+bool Config::isSerialTcpEnabled() {
+    return getBoolSetting(m_prefGeneral, "serial_tcp", false);
+}
+
+uint8_t Config::getSerialBuffering(uint8_t port) {
+    char keyname[16];
+    snprintf(keyname, sizeof(keyname), "serial%u_bm", port);
+    return getUCharSetting(m_prefGeneral, keyname, 0);
+}
+
+bool Config::setSerialBuffering(uint8_t port, uint8_t mode) {
+    char keyname[16];
+    snprintf(keyname, sizeof(keyname), "serial%u_bm", port);
+    return setUCharSetting(m_prefGeneral, keyname, mode);
+}
+
+uint8_t Config::getSerialTerminatorChar(uint8_t port) {
+    char keyname[16];
+    snprintf(keyname, sizeof(keyname), "serial%u_tc", port);
+    return getUCharSetting(m_prefGeneral, keyname, '\n');
+}
+
+bool Config::setSerialTerminatorChar(uint8_t port, uint8_t terminator) {
+    char keyname[16];
+    snprintf(keyname, sizeof(keyname), "serial%u_tc", port);
+    return setUCharSetting(m_prefGeneral, keyname, terminator);
+}
+
+uint16_t Config::getSerialBufferSize(uint8_t port) {
+    char keyname[16];
+    snprintf(keyname, sizeof(keyname), "serial%u_bs", port);
+    return getUShortSetting(m_prefGeneral, keyname, 512);
+}
+
+bool Config::setSerialBufferSize(uint8_t port, uint16_t size) {
+    char keyname[16];
+    snprintf(keyname, sizeof(keyname), "serial%u_bs", port);
+    return setUShortSetting(m_prefGeneral, keyname, size);
+}
+
+uint16_t Config::getSerialTimeout(uint8_t port) {
+    char keyname[16];
+    snprintf(keyname, sizeof(keyname), "serial%u_to", port);
+    return getUShortSetting(m_prefGeneral, keyname, 100);
+}
+
+bool Config::setSerialTimeout(uint8_t port, uint16_t timeout_ms) {
+    char keyname[16];
+    snprintf(keyname, sizeof(keyname), "serial%u_to", port);
+    return setUShortSetting(m_prefGeneral, keyname, timeout_ms);
 }
 
 // reset config to defaults
@@ -512,12 +504,30 @@ std::string Config::getStringSetting(const char* partition, const char* key, con
     return value;
 }
 
+bool Config::setStringSetting(const char* partition, const char* key, const std::string& value) {
+    if (!m_preferences.begin(partition, false)) {
+        return false;
+    }
+    size_t len = m_preferences.putString(key, value);
+    m_preferences.end();
+    return len > 0;
+}
+
 bool Config::getBoolSetting(const char* partition, const char* key, bool defaultValue) {
     m_preferences.begin(partition, false);
     auto value = m_preferences.getBool(key, defaultValue);
     m_preferences.end();
 
     return value;
+}
+
+bool Config::setBoolSetting(const char* partition, const char* key, bool value) {
+    if (!m_preferences.begin(partition, false)) {
+        return false;
+    }
+    m_preferences.putBool(key, value);
+    m_preferences.end();
+    return true;
 }
 
 uint8_t Config::getUCharSetting(const char* partition, const char* key, uint8_t defaultValue) {
@@ -528,12 +538,30 @@ uint8_t Config::getUCharSetting(const char* partition, const char* key, uint8_t 
     return value;
 }
 
+bool Config::setUCharSetting(const char* partition, const char* key, uint8_t value) {
+    if (!m_preferences.begin(partition, false)) {
+        return false;
+    }
+    m_preferences.putUChar(key, value);
+    m_preferences.end();
+    return true;
+}
+
 uint16_t Config::getUShortSetting(const char* partition, const char* key, uint16_t defaultValue) {
     m_preferences.begin(partition, false);
     auto value = m_preferences.getUShort(key, defaultValue);
     m_preferences.end();
 
     return value;
+}
+
+bool Config::setUShortSetting(const char* partition, const char* key, uint16_t value) {
+    if (!m_preferences.begin(partition, false)) {
+        return false;
+    }
+    m_preferences.putUShort(key, value);
+    m_preferences.end();
+    return true;
 }
 
 int Config::getIntSetting(const char* partition, const char* key, int defaultValue) {

--- a/components/preferences/config.h
+++ b/components/preferences/config.h
@@ -189,6 +189,50 @@ class Config {
     bool enableGcServerBeacon(bool enable);
     bool isGcServerBeaconEnabled();
 
+    // Serial TCP bridge configuration
+    bool enableSerialTcp(bool enable);
+    bool isSerialTcpEnabled();
+
+    /// @brief Get serial buffering mode for a port.
+    /// @param port port number, 1-based.
+    /// @return Buffer mode (0: "line", 1: "chunk"). Returns 0 if not configured.
+    uint8_t getSerialBuffering(uint8_t port);
+
+    /// @brief Set serial buffering mode for a port.
+    /// @param port port number, 1-based.
+    /// @param mode 0: "line", 1: "chunk"
+    bool setSerialBuffering(uint8_t port, uint8_t mode);
+
+    /// @brief Get serial terminator character for a port.
+    /// @param port port number, 1-based.
+    /// @return Terminator character. Returns '\n' if not configured.
+    uint8_t getSerialTerminatorChar(uint8_t port);
+
+    /// @brief Set serial terminator character for a port.
+    /// @param port port number, 1-based.
+    /// @param terminator Single terminator character.
+    bool setSerialTerminatorChar(uint8_t port, uint8_t terminator);
+
+    /// @brief Get serial buffer size for a port.
+    /// @param port port number, 1-based.
+    /// @return Buffer size in bytes. Returns 0 if not configured (use default).
+    uint16_t getSerialBufferSize(uint8_t port);
+
+    /// @brief Set serial buffer size for a port.
+    /// @param port port number, 1-based.
+    /// @param size Buffer size in bytes (1–16384).
+    bool setSerialBufferSize(uint8_t port, uint16_t size);
+
+    /// @brief Get serial timeout for a port.
+    /// @param port port number, 1-based.
+    /// @return Timeout in milliseconds. Returns 0 if not configured (use default).
+    uint16_t getSerialTimeout(uint8_t port);
+
+    /// @brief Set serial timeout for a port.
+    /// @param port port number, 1-based.
+    /// @param timeout_ms Timeout in milliseconds. 0 = no timeout.
+    bool setSerialTimeout(uint8_t port, uint16_t timeout_ms);
+
     // reset config to defaults
     void reset();
 
@@ -201,9 +245,13 @@ class Config {
 
     std::string getStringSetting(const char* partition, const char* key,
                                  const std::string defaultValue = std::string());
+    bool        setStringSetting(const char* partition, const char* key, const std::string& value);
     bool        getBoolSetting(const char* partition, const char* key, bool defaultValue = false);
+    bool        setBoolSetting(const char* partition, const char* key, bool value);
     uint8_t     getUCharSetting(const char* partition, const char* key, uint8_t defaultValue = 0);
+    bool        setUCharSetting(const char* partition, const char* key, uint8_t value);
     uint16_t    getUShortSetting(const char* partition, const char* key, uint16_t defaultValue = 0);
+    bool        setUShortSetting(const char* partition, const char* key, uint16_t value);
     int         getIntSetting(const char* partition, const char* key, int defaultValue = 0);
     uint32_t    getUIntSetting(const char* partition, const char* key, uint32_t defaultValue = 0);
 

--- a/components/serial_bridge/CMakeLists.txt
+++ b/components/serial_bridge/CMakeLists.txt
@@ -1,0 +1,11 @@
+idf_component_register(
+    SRCS
+    "serial_bridge.cpp"
+    "serial_port_buffer.cpp"
+    INCLUDE_DIRS
+    "include"
+    REQUIRES
+    driver
+    esp_event
+    log
+)

--- a/components/serial_bridge/include/serial_bridge.h
+++ b/components/serial_bridge/include/serial_bridge.h
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Unfolded Circle ApS and/or its affiliates <hello@unfoldedcircle.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <stdint.h>
+
+#include "driver/uart.h"
+#include "esp_err.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#define BRIDGE_RX_BUF_SIZE 256
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct serial_bridge serial_bridge_t;
+
+/// Callback invoked on the bridge task for UART RX data or idle tick.
+/// - data != NULL, len > 0: new UART data received
+/// - data == NULL, len == 0: idle tick (called every ~20ms for timeout processing)
+/// Implementations MUST be non-blocking.
+/// @param port_index 1-based port number
+/// @param data pointer to received bytes, or NULL for idle tick
+/// @param len number of bytes, or 0 for idle tick
+/// @param user_ctx context pointer provided at registration
+typedef void (*serial_bridge_rx_cb_t)(uint8_t port_index, const uint8_t *data, size_t len, void *user_ctx);
+
+typedef struct {
+    uint8_t       port_index;        ///< 1-based port number
+    uart_port_t   uart_num;          ///< UART port number (from ext_port_config_t)
+    QueueHandle_t uart_event_queue;  ///< UART event queue (owned by ExternalPort)
+    uint16_t      tcp_port;          ///< TCP listen port (4999, 5000)
+    bool          tcp_enabled;       ///< Enable TCP server (false = UART + rx_callback only)
+} serial_bridge_config_t;
+
+/// Create a serial bridge instance. Does NOT start it.
+serial_bridge_t *serial_bridge_create(const serial_bridge_config_t *config);
+
+/// Start the bridge task (TCP server + UART bridging).
+/// Call only when UART driver is installed and port is in RS232 mode.
+esp_err_t serial_bridge_start(serial_bridge_t *bridge);
+
+/// Stop the bridge task and close all TCP connections.
+/// Safe to call if not started. Blocks until task exits.
+esp_err_t serial_bridge_stop(serial_bridge_t *bridge);
+
+/// Destroy the bridge instance and free all resources.
+void serial_bridge_destroy(serial_bridge_t *bridge);
+
+/// Send data to UART from an external source (e.g. WebSocket API).
+/// Thread-safe. Non-blocking (uses UART TX ringbuffer).
+esp_err_t serial_bridge_send_to_uart(serial_bridge_t *bridge, const uint8_t *data, size_t len);
+
+/// Set the UART RX callback (e.g. for WebSocket forwarding).
+/// Called from bridge task context. Only one callback supported. Pass NULL to clear.
+void serial_bridge_set_rx_callback(serial_bridge_t *bridge, serial_bridge_rx_cb_t cb, void *user_ctx);
+
+/// Update the UART event queue handle (needed after UART re-initialization).
+void serial_bridge_set_uart_queue(serial_bridge_t *bridge, QueueHandle_t queue);
+
+/// Enable or disable the TCP server. Takes effect on next serial_bridge_start().
+void serial_bridge_set_tcp_enabled(serial_bridge_t *bridge, bool enabled);
+
+/// Check if the bridge task is currently running.
+bool serial_bridge_is_running(const serial_bridge_t *bridge);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/serial_bridge/include/serial_port_buffer.h
+++ b/components/serial_bridge/include/serial_port_buffer.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Unfolded Circle ApS and/or its affiliates <hello@unfoldedcircle.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
+/// Per-port serial buffering configuration and runtime state
+struct SerialPortBuffer {
+    enum Mode { LINE = 0, CHUNK = 1 };
+
+    // Configuration (persisted via Config class)
+    Mode     mode = LINE;
+    uint8_t  terminator = '\n';
+    size_t   buffer_size = 512;
+    uint32_t timeout_ms = 100;
+
+    // Runtime state
+    uint8_t          *buf = nullptr;
+    size_t            len = 0;
+    int64_t           last_rx_us = 0;  // esp_timer_get_time() when last byte was buffered
+    SemaphoreHandle_t mutex = nullptr;
+
+    /// Allocate buffer based on current buffer_size. Returns true on success.
+    bool allocate();
+    /// Free buffer memory.
+    void deallocate();
+    /// Reset buffer state (clear contents, keep allocation).
+    void reset();
+};

--- a/components/serial_bridge/serial_bridge.cpp
+++ b/components/serial_bridge/serial_bridge.cpp
@@ -1,0 +1,487 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Unfolded Circle ApS and/or its affiliates <hello@unfoldedcircle.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "serial_bridge.h"
+
+#include <cerrno>
+#include <cstring>
+
+#include "esp_log.h"
+#include "esp_task_wdt.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "lwip/sockets.h"
+
+static const char *const TAG = "SER_BR";
+
+#define MAX_CLIENTS_PER_PORT 8
+#define BRIDGE_TASK_STACK_SIZE 4096
+#define BRIDGE_TASK_PRIORITY 5
+#define BRIDGE_TASK_CORE 0
+#define SELECT_TIMEOUT_US 20000  // 20ms
+#define STOP_WAIT_ITERATIONS 25  // 25 * 20ms = 500ms max wait
+
+#ifndef MIN
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+struct serial_bridge {
+    serial_bridge_config_t config;
+    TaskHandle_t           task_handle;
+    volatile bool          running;
+
+    int     listen_fd;
+    int     client_fds[MAX_CLIENTS_PER_PORT];
+    uint8_t client_count;
+
+    serial_bridge_rx_cb_t rx_callback;
+    void                 *rx_callback_ctx;
+};
+
+// --- Forward declarations ---
+static void bridge_task(void *arg);
+static int  create_tcp_server(uint16_t port);
+static void accept_client(serial_bridge_t *br);
+static void close_client(serial_bridge_t *br, int slot);
+static void broadcast_to_clients(serial_bridge_t *br, const uint8_t *data, size_t len);
+static void notify_rx_callback(serial_bridge_t *br, const uint8_t *data, size_t len);
+static int  build_fd_set(serial_bridge_t *br, fd_set *read_fds);
+static void cleanup_sockets(serial_bridge_t *br);
+
+// --- Public API ---
+
+serial_bridge_t *serial_bridge_create(const serial_bridge_config_t *config) {
+    if (!config) {
+        return nullptr;
+    }
+
+    auto *br = static_cast<serial_bridge_t *>(calloc(1, sizeof(serial_bridge_t)));
+    if (!br) {
+        ESP_LOGE(TAG, "Failed to allocate serial_bridge_t");
+        return nullptr;
+    }
+
+    br->config = *config;
+    br->task_handle = nullptr;
+    br->running = false;
+    br->listen_fd = -1;
+    br->client_count = 0;
+    br->rx_callback = nullptr;
+    br->rx_callback_ctx = nullptr;
+
+    for (int i = 0; i < MAX_CLIENTS_PER_PORT; i++) {
+        br->client_fds[i] = -1;
+    }
+
+    ESP_LOGI(TAG, "Port %d: bridge instance created (TCP port %d %s, UART %d)", config->port_index, config->tcp_port,
+             config->tcp_enabled ? "enabled" : "disabled", config->uart_num);
+
+    return br;
+}
+
+esp_err_t serial_bridge_start(serial_bridge_t *bridge) {
+    if (!bridge) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (bridge->running) {
+        ESP_LOGW(TAG, "Port %d: bridge already running", bridge->config.port_index);
+        return ESP_OK;
+    }
+
+    bridge->running = true;
+    bridge->listen_fd = -1;
+    bridge->client_count = 0;
+
+    for (int i = 0; i < MAX_CLIENTS_PER_PORT; i++) {
+        bridge->client_fds[i] = -1;
+    }
+
+    char name[16];
+    snprintf(name, sizeof(name), "ser_br_%d", bridge->config.port_index);
+
+    BaseType_t ret = xTaskCreatePinnedToCore(bridge_task, name, BRIDGE_TASK_STACK_SIZE, bridge, BRIDGE_TASK_PRIORITY,
+                                             &bridge->task_handle, BRIDGE_TASK_CORE);
+
+    if (ret != pdPASS) {
+        bridge->running = false;
+        ESP_LOGE(TAG, "Port %d: failed to create bridge task", bridge->config.port_index);
+        return ESP_ERR_NO_MEM;
+    }
+
+    ESP_LOGI(TAG, "Port %d: bridge started (TCP %s)", bridge->config.port_index,
+             bridge->config.tcp_enabled ? "enabled" : "disabled");
+    return ESP_OK;
+}
+
+esp_err_t serial_bridge_stop(serial_bridge_t *bridge) {
+    if (!bridge) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (!bridge->running) {
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "Port %d: stopping bridge...", bridge->config.port_index);
+    bridge->running = false;
+
+    // Wait for task to exit
+    for (int i = 0; i < STOP_WAIT_ITERATIONS; i++) {
+        if (bridge->task_handle == nullptr) {
+            break;
+        }
+        vTaskDelay(pdMS_TO_TICKS(20));
+    }
+
+    if (bridge->task_handle != nullptr) {
+        ESP_LOGW(TAG, "Port %d: force-deleting bridge task", bridge->config.port_index);
+        vTaskDelete(bridge->task_handle);
+        cleanup_sockets(bridge);
+        bridge->task_handle = nullptr;
+    }
+
+    ESP_LOGI(TAG, "Port %d: bridge stopped", bridge->config.port_index);
+    return ESP_OK;
+}
+
+void serial_bridge_destroy(serial_bridge_t *bridge) {
+    if (!bridge) {
+        return;
+    }
+
+    serial_bridge_stop(bridge);
+
+    ESP_LOGI(TAG, "Port %d: bridge instance destroyed", bridge->config.port_index);
+    free(bridge);
+}
+
+esp_err_t serial_bridge_send_to_uart(serial_bridge_t *bridge, const uint8_t *data, size_t len) {
+    if (!bridge || !data || len == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (!bridge->running) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    int written = uart_write_bytes(bridge->config.uart_num, data, len);
+    if (written < 0) {
+        return ESP_FAIL;
+    }
+    return (static_cast<size_t>(written) == len) ? ESP_OK : ESP_ERR_TIMEOUT;
+}
+
+void serial_bridge_set_rx_callback(serial_bridge_t *bridge, serial_bridge_rx_cb_t cb, void *user_ctx) {
+    if (!bridge) {
+        return;
+    }
+    bridge->rx_callback_ctx = user_ctx;
+    bridge->rx_callback = cb;
+}
+
+void serial_bridge_set_uart_queue(serial_bridge_t *bridge, QueueHandle_t queue) {
+    if (bridge) {
+        bridge->config.uart_event_queue = queue;
+    }
+}
+
+void serial_bridge_set_tcp_enabled(serial_bridge_t *bridge, bool enabled) {
+    if (bridge) {
+        bridge->config.tcp_enabled = enabled;
+    }
+}
+
+bool serial_bridge_is_running(const serial_bridge_t *bridge) {
+    if (!bridge) {
+        return false;
+    }
+    return bridge->running;
+}
+
+// --- Internal Implementation ---
+
+static int create_tcp_server(uint16_t port) {
+    int fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (fd < 0) {
+        ESP_LOGE(TAG, "Failed to create socket: errno %d", errno);
+        return -1;
+    }
+
+    int opt = 1;
+    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    struct sockaddr_in addr = {};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    if (bind(fd, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) < 0) {
+        ESP_LOGE(TAG, "Failed to bind port %d: errno %d", port, errno);
+        close(fd);
+        return -1;
+    }
+
+    if (listen(fd, MAX_CLIENTS_PER_PORT) < 0) {
+        ESP_LOGE(TAG, "Failed to listen on port %d: errno %d", port, errno);
+        close(fd);
+        return -1;
+    }
+
+    // Set non-blocking
+    int flags = fcntl(fd, F_GETFL, 0);
+    fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+    return fd;
+}
+
+static void accept_client(serial_bridge_t *br) {
+    struct sockaddr_in client_addr = {};
+    socklen_t          addr_len = sizeof(client_addr);
+
+    int client_fd = accept(br->listen_fd, reinterpret_cast<struct sockaddr *>(&client_addr), &addr_len);
+    if (client_fd < 0) {
+        return;
+    }
+
+    if (br->client_count >= MAX_CLIENTS_PER_PORT) {
+        ESP_LOGW(TAG, "Port %d: max clients (%d) reached, rejecting", br->config.port_index, MAX_CLIENTS_PER_PORT);
+        close(client_fd);
+        return;
+    }
+
+    // TCP_NODELAY for low latency
+    int opt = 1;
+    setsockopt(client_fd, IPPROTO_TCP, TCP_NODELAY, &opt, sizeof(opt));
+
+    // Keep-alive to detect dead connections
+    setsockopt(client_fd, SOL_SOCKET, SO_KEEPALIVE, &opt, sizeof(opt));
+    int idle = 60;
+    int interval = 10;
+    int count = 3;
+    setsockopt(client_fd, IPPROTO_TCP, TCP_KEEPIDLE, &idle, sizeof(idle));
+    setsockopt(client_fd, IPPROTO_TCP, TCP_KEEPINTVL, &interval, sizeof(interval));
+    setsockopt(client_fd, IPPROTO_TCP, TCP_KEEPCNT, &count, sizeof(count));
+
+    // Send timeout to prevent blocking on slow clients
+    struct timeval send_timeout = {.tv_sec = 5, .tv_usec = 0};
+    setsockopt(client_fd, SOL_SOCKET, SO_SNDTIMEO, &send_timeout, sizeof(send_timeout));
+
+    // Non-blocking
+    int flags = fcntl(client_fd, F_GETFL, 0);
+    fcntl(client_fd, F_SETFL, flags | O_NONBLOCK);
+
+    // Find free slot
+    for (int i = 0; i < MAX_CLIENTS_PER_PORT; i++) {
+        if (br->client_fds[i] < 0) {
+            br->client_fds[i] = client_fd;
+            br->client_count++;
+
+            char addr_str[INET_ADDRSTRLEN];
+            inet_ntoa_r(client_addr.sin_addr, addr_str, sizeof(addr_str));
+            ESP_LOGI(TAG, "Port %d: client connected from %s:%d (slot %d, fd %d, total %d)", br->config.port_index,
+                     addr_str, ntohs(client_addr.sin_port), i, client_fd, br->client_count);
+            return;
+        }
+    }
+
+    // Should not happen due to count check, safety net
+    close(client_fd);
+}
+
+static void close_client(serial_bridge_t *br, int slot) {
+    if (slot < 0 || slot >= MAX_CLIENTS_PER_PORT || br->client_fds[slot] < 0) {
+        return;
+    }
+
+    ESP_LOGI(TAG, "Port %d: client disconnected (slot %d, fd %d)", br->config.port_index, slot, br->client_fds[slot]);
+
+    close(br->client_fds[slot]);
+    br->client_fds[slot] = -1;
+    if (br->client_count > 0) {
+        br->client_count--;
+    }
+}
+
+static void broadcast_to_clients(serial_bridge_t *br, const uint8_t *data, size_t len) {
+    for (int i = 0; i < MAX_CLIENTS_PER_PORT; i++) {
+        if (br->client_fds[i] < 0) {
+            continue;
+        }
+
+        int sent = send(br->client_fds[i], data, len, MSG_DONTWAIT);
+        if (sent < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                ESP_LOGW(TAG, "Port %d: client slot %d send buffer full, dropping %d bytes", br->config.port_index, i,
+                         (int)len);
+            } else {
+                ESP_LOGW(TAG, "Port %d: client slot %d send error (errno %d), closing", br->config.port_index, i,
+                         errno);
+                close_client(br, i);
+            }
+        }
+    }
+}
+
+static void notify_rx_callback(serial_bridge_t *br, const uint8_t *data, size_t len) {
+    if (br->rx_callback) {
+        br->rx_callback(br->config.port_index, data, len, br->rx_callback_ctx);
+    }
+}
+
+static int build_fd_set(serial_bridge_t *br, fd_set *read_fds) {
+    FD_ZERO(read_fds);
+
+    int max_fd = br->listen_fd;
+    FD_SET(br->listen_fd, read_fds);
+
+    for (int i = 0; i < MAX_CLIENTS_PER_PORT; i++) {
+        if (br->client_fds[i] >= 0) {
+            FD_SET(br->client_fds[i], read_fds);
+            if (br->client_fds[i] > max_fd) {
+                max_fd = br->client_fds[i];
+            }
+        }
+    }
+
+    return max_fd;
+}
+
+static void cleanup_sockets(serial_bridge_t *br) {
+    for (int i = 0; i < MAX_CLIENTS_PER_PORT; i++) {
+        if (br->client_fds[i] >= 0) {
+            close(br->client_fds[i]);
+            br->client_fds[i] = -1;
+        }
+    }
+    br->client_count = 0;
+
+    if (br->listen_fd >= 0) {
+        close(br->listen_fd);
+        br->listen_fd = -1;
+    }
+}
+
+static void bridge_task(void *arg) {
+    auto   *br = static_cast<serial_bridge_t *>(arg);
+    uint8_t rx_buf[BRIDGE_RX_BUF_SIZE];
+    bool    tcp_active = br->config.tcp_enabled;
+
+    // Subscribe to task watchdog
+    esp_task_wdt_add(NULL);
+
+    // Only create TCP server if enabled
+    if (tcp_active) {
+        br->listen_fd = create_tcp_server(br->config.tcp_port);
+        if (br->listen_fd < 0) {
+            ESP_LOGE(TAG, "Port %d: failed to create TCP server on port %d", br->config.port_index,
+                     br->config.tcp_port);
+            // Continue without TCP — still service UART for rx_callback
+            tcp_active = false;
+        } else {
+            ESP_LOGI(TAG, "Port %d: TCP server listening on port %d", br->config.port_index, br->config.tcp_port);
+        }
+    } else {
+        ESP_LOGI(TAG, "Port %d: TCP disabled, UART callback only", br->config.port_index);
+    }
+
+    while (br->running) {
+        esp_task_wdt_reset();
+
+        if (tcp_active) {
+            fd_set read_fds;
+            int    max_fd = build_fd_set(br, &read_fds);
+
+            struct timeval tv = {.tv_sec = 0, .tv_usec = SELECT_TIMEOUT_US};
+            int            ready = select(max_fd + 1, &read_fds, NULL, NULL, &tv);
+
+            if (ready > 0) {
+                // Accept new connections
+                if (FD_ISSET(br->listen_fd, &read_fds)) {
+                    accept_client(br);
+                }
+
+                // Read from TCP clients → write to UART
+                for (int i = 0; i < MAX_CLIENTS_PER_PORT; i++) {
+                    if (br->client_fds[i] < 0) {
+                        continue;
+                    }
+                    if (!FD_ISSET(br->client_fds[i], &read_fds)) {
+                        continue;
+                    }
+
+                    int n = recv(br->client_fds[i], rx_buf, sizeof(rx_buf), 0);
+                    if (n > 0) {
+                        uart_write_bytes(br->config.uart_num, rx_buf, n);
+                    } else if (n == 0) {
+                        close_client(br, i);
+                    } else {
+                        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                            close_client(br, i);
+                        }
+                    }
+                }
+            } else if (ready < 0) {
+                if (errno != EINTR) {
+                    ESP_LOGE(TAG, "Port %d: select() error: errno %d", br->config.port_index, errno);
+                    vTaskDelay(pdMS_TO_TICKS(100));
+                }
+            }
+        } else {
+            // No TCP: just wait for UART events with a delay
+            vTaskDelay(pdMS_TO_TICKS(SELECT_TIMEOUT_US / 1000));
+        }
+
+        // Drain UART event queue → broadcast to TCP clients + callback
+        if (br->config.uart_event_queue != NULL) {
+            uart_event_t event;
+            while (xQueueReceive(br->config.uart_event_queue, &event, 0) == pdTRUE) {
+                switch (event.type) {
+                    case UART_DATA: {
+                        if (event.size == 0) {
+                            break;
+                        }
+                        size_t remaining = event.size;
+                        while (remaining > 0) {
+                            size_t chunk_size = MIN(remaining, sizeof(rx_buf));
+                            int    len = uart_read_bytes(br->config.uart_num, rx_buf, chunk_size, 0);
+                            if (len <= 0) {
+                                break;
+                            }
+                            if (tcp_active) {
+                                broadcast_to_clients(br, rx_buf, len);
+                            }
+                            notify_rx_callback(br, rx_buf, len);
+                            remaining -= len;
+                        }
+                        break;
+                    }
+                    case UART_FIFO_OVF:
+                    case UART_BUFFER_FULL:
+                        ESP_LOGW(TAG, "Port %d: UART %s, flushing", br->config.port_index,
+                                 event.type == UART_FIFO_OVF ? "FIFO overflow" : "buffer full");
+                        uart_flush_input(br->config.uart_num);
+                        xQueueReset(br->config.uart_event_queue);
+                        break;
+                    case UART_FRAME_ERR:
+                        ESP_LOGW(TAG, "Port %d: UART frame error", br->config.port_index);
+                        break;
+                    case UART_PARITY_ERR:
+                        ESP_LOGW(TAG, "Port %d: UART parity error", br->config.port_index);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        // Idle tick for timeout processing (called every iteration)
+        notify_rx_callback(br, NULL, 0);
+    }
+
+    // Cleanup
+    cleanup_sockets(br);
+    esp_task_wdt_delete(NULL);
+
+    ESP_LOGI(TAG, "Port %d: bridge task exiting", br->config.port_index);
+    br->task_handle = nullptr;
+    vTaskDelete(NULL);
+}

--- a/components/serial_bridge/serial_port_buffer.cpp
+++ b/components/serial_bridge/serial_port_buffer.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Unfolded Circle ApS and/or its affiliates <hello@unfoldedcircle.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "serial_port_buffer.h"
+
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+
+static const char *const TAG = "SER_BUF";
+static const size_t      SERIAL_BUFFER_PSRAM_THRESHOLD = 1024;
+
+bool SerialPortBuffer::allocate() {
+    deallocate();
+
+    if (buffer_size >= SERIAL_BUFFER_PSRAM_THRESHOLD) {
+        buf = static_cast<uint8_t *>(heap_caps_malloc(buffer_size, MALLOC_CAP_SPIRAM));
+    }
+    if (!buf) {
+        buf = static_cast<uint8_t *>(heap_caps_malloc(buffer_size, MALLOC_CAP_INTERNAL));
+    }
+    if (!buf) {
+        ESP_LOGE(TAG, "Failed to allocate serial buffer (%d bytes)", buffer_size);
+        return false;
+    }
+
+    if (!mutex) {
+        mutex = xSemaphoreCreateMutex();
+        if (!mutex) {
+            deallocate();
+            return false;
+        }
+    }
+
+    len = 0;
+    last_rx_us = 0;
+    return true;
+}
+
+void SerialPortBuffer::deallocate() {
+    if (buf) {
+        heap_caps_free(buf);
+        buf = nullptr;
+    }
+    len = 0;
+    last_rx_us = 0;
+}
+
+void SerialPortBuffer::reset() {
+    len = 0;
+    last_rx_us = 0;
+}

--- a/doc/serial-bridge.md
+++ b/doc/serial-bridge.md
@@ -1,0 +1,476 @@
+# Serial Bridge Component
+
+## Overview
+
+The Serial Bridge component provides bidirectional RS232-to-network bridging for the two
+configurable external ports on the UCD3 dock. Each external port can be independently
+configured to operate in RS232 mode, enabling serial communication with AV devices such
+as receivers, projectors, and media players.
+
+The component offers two parallel data paths:
+
+1. **Raw TCP Server** (optional): GlobalCache iTach-compatible TCP passthrough on ports
+   4999 and 5000. Up to 8 simultaneous clients per port. Data is forwarded 1:1 without
+   framing or interpretation.
+
+2. **WebSocket JSON API**: Line-based or chunk-based serial data forwarding to subscribed
+   WebSocket clients. Supports configurable buffering, terminator character, and idle
+   timeouts for protocol-aware message framing.
+
+Both paths can operate simultaneously on the same serial port.
+
+
+## Architecture
+
+### Task-based Design (not Interrupt-driven)
+
+Each serial port runs a dedicated FreeRTOS task when in RS232 mode. This decision was
+made for the following reasons:
+
+- UART ISRs are already handled internally by the IDF UART driver (FIFO thresholds,
+  ring buffer management)
+- lwIP socket operations (`send()`, `recv()`, `select()`) are not ISR-safe
+- Per-port task isolation: a failure on one port does not affect the other
+- Minimal overhead: ~4 KB stack per task
+
+The bridge task is pinned to **Core 0** at **priority 5**. Core 1 is reserved for
+time-critical IR sending (priority 18).
+
+### Resource Budget
+
+| Resource               | Per Port   | Total (2 Ports) |
+|------------------------|------------|-----------------|
+| Task Stack             | 4096 Byte  | 8192 Byte       |
+| UART RX Buffer         | 2048 Byte  | 4096 Byte       |
+| UART TX Buffer         | 512 Byte   | 1024 Byte       |
+| UART Event Queue       | 320 Byte   | 640 Byte        |
+| Bridge struct          | ~220 Byte  | ~440 Byte       |
+| Task rx_buf            | 256 Byte   | 512 Byte        |
+| TCP Sockets (lwIP)     | ~4 KB max  | ~8 KB max       |
+| Serial line buffer     | 512 Byte*  | 1024 Byte*      |
+
+*Line buffer size is configurable (1–16384 bytes).
+
+
+## TCP Server
+
+### Port Mapping (GlobalCache-compatible)
+
+| Port Index | UART       | TCP Port |
+|------------|------------|----------|
+| 1          | UART_NUM_1 | 4999     |
+| 2          | UART_NUM_2 | 5000     |
+
+### Configuration
+
+TCP servers are optional and can be enabled/disabled globally via the `Config` class:
+
+```cpp
+config->enableSerialTcp(true);   // Enable TCP servers
+config->isSerialTcpEnabled();    // Query current state
+```
+
+When disabled, the bridge task still runs (servicing the UART for WebSocket callbacks)
+but does not open TCP listening sockets.
+
+#### Multi-Client Behavior
+
+- Maximum 8 simultaneous TCP connections per port
+- The 9th connection attempt is accepted and immediately closed (connection refused)
+- UART RX → TCP: Received serial data is broadcast to ALL connected TCP clients
+- TCP → UART: Any connected client can send data; all data is forwarded to the UART
+  in order of arrival
+- There is no arbitration or locking between clients sending concurrently. Bytes from
+  different clients may interleave at the UART if they send simultaneously.
+
+#### Socket Configuration
+
+| Option          | Value     | Purpose                              |
+|-----------------|-----------|--------------------------------------|
+| `SO_REUSEADDR`  | enabled   | Quick rebind after restart           |
+| `TCP_NODELAY`   | enabled   | Low latency for control protocols    |
+| `SO_KEEPALIVE`  | enabled   | Detect dead connections              |
+| `TCP_KEEPIDLE`  | 60s       | Time before first keep-alive probe   |
+| `TCP_KEEPINTVL` | 10s       | Interval between probes              |
+| `TCP_KEEPCNT`   | 3         | Probes before declaring dead         |
+| `SO_SNDTIMEO`   | 5s        | Send timeout (prevents blocking)     |
+| `O_NONBLOCK`    | enabled   | Non-blocking I/O                     |
+
+#### Error Handling
+
+| Situation                    | Behavior                                      |
+|------------------------------|-----------------------------------------------|
+| Client disconnect            | Close socket, free slot, continue operation    |
+| `send()` returns EAGAIN      | Drop data for this client, log warning         |
+| `send()` returns other error | Close client                                   |
+| `select()` error             | Log, delay 100ms, retry                        |
+| TCP bind failure             | Task continues without TCP (callback-only)     |
+
+## Bridge Task Loop
+
+The bridge task uses a select()-based event loop with a 20ms timeout:
+
+```
+while (running) {
+    1. Reset task watchdog
+    2. If TCP enabled:
+       - select() on listen_fd + all client_fds (20ms timeout)
+       - Accept new connections
+       - Read from TCP clients → uart_write_bytes()
+    3. If TCP disabled:
+       - vTaskDelay(20ms)
+    4. Drain UART event queue (non-blocking):
+       - UART_DATA → read bytes → broadcast to TCP + notify rx_callback
+       - UART_FIFO_OVF / UART_BUFFER_FULL → flush + reset queue
+       - UART_FRAME_ERR / UART_PARITY_ERR → log warning
+    5. Notify idle tick (rx_callback with NULL data for timeout processing)
+}
+```
+
+### Task Watchdog
+
+The bridge task subscribes to the ESP-IDF Task Watchdog Timer (TWDT) for 24/7
+reliability:
+
+- `esp_task_wdt_add(NULL)` — Subscribe at task start
+- `esp_task_wdt_reset()` — Feed watchdog every loop iteration (~20ms)
+- `esp_task_wdt_delete(NULL)` — Unsubscribe before task deletion
+
+If the task fails to feed the watchdog within the configured timeout
+(`CONFIG_ESP_TASK_WDT_TIMEOUT_S`, typically 5s), the system logs an error or panics
+depending on configuration.
+
+## Data Flow
+
+```
+    ┌─────────────────────────────────────────────────────────────────────┐
+    │                          bridge_task                                │
+    │                     (1 task per serial port)                        │
+    ├─────────────────────────────────────────────────────────────────────┤
+    │                                                                     │
+    │  TCP → UART:                                                        │
+    │                                                                     │
+    │  TCP Client 1 ──┐                                                   │
+    │  TCP Client 2 ──┼── recv() ──► uart_write_bytes() ──► UART TX       │
+    │  TCP Client N ──┘                                                   │
+    │                                                                     │
+    │                                                                     │
+    │  UART → TCP + Callback:                                             │
+    │                                                                     │
+    │  UART RX ──► uart_event_queue ──► uart_read_bytes()                 │
+    │                                         │                           │
+    │                               ┌─────────┴──────────┐                │
+    │                               ▼                    ▼                │
+    │                   broadcast_to_clients()    rx_callback()           │
+    │                               │                    │                │
+    │                               ▼                    │                │
+    │                     send() to each                 │                │
+    │                     TCP Client 1..N                │                │
+    │                                                    │                │
+    └────────────────────────────────────────────────────┼────────────────┘
+                                                         │
+                                                         ▼
+    ┌────────────────────────────────────────────────────────────────────┐
+    │                     DockApi (httpd task)                           │
+    ├────────────────────────────────────────────────────────────────────┤
+    │                                                                    │
+    │  handleSerialRx()                                                  │
+    │       │                                                            │
+    │       ├── CHUNK mode: send immediately via sendSerialEvent()       │
+    │       │                                                            │
+    │       ├── LINE mode: buffer until terminator or timeout            │
+    │       │       │                                                    │
+    │       │       ├── terminator found → flushSerialBuffer()           │
+    │       │       ├── buffer full → flushSerialBuffer()                │
+    │       │       └── idle tick + timeout elapsed → flushSerialBuffer()│
+    │       │                                                            │
+    │       └── sendSerialEvent()                                        │
+    │                 │                                                  │
+    │                 ▼                                                  │
+    │    Build JSON: {"type":"event","msg":"serial_data","port":N,...}   │
+    │                 │                                                  │
+    │                 ▼                                                  │
+    │    web_->sendWsTxt(fd, msg) → subscribed WS clients only           │
+    │                                                                    │
+    │                                                                    │
+    │  WS → UART (send_serial command):                                  │
+    │                                                                    │
+    │  WS Client ──► processSendSerial()                                 │
+    │                      │                                             │
+    │                      ▼                                             │
+    │        serial_bridge_send_to_uart() ──► uart_write_bytes()         │
+    │                                              │                     │
+    │                                              ▼                     │
+    │                                           UART TX                  │
+    │                                                                    │
+    └────────────────────────────────────────────────────────────────────┘
+```
+
+Summary:
+```
+    ┌──────────────┐         ┌──────────────┐         ┌──────────────┐
+    │  TCP Client  │◄───────►│              │◄───────►│   UART Port  │
+    │  (raw TCP)   │  send/  │ bridge_task  │  read/  │              │
+    │  port 4999+  │  recv   │              │  write  │  UART_NUM_x  │
+    └──────────────┘         └──────┬───────┘         └──────────────┘
+                                    │ rx_callback             ▲
+                                    ▼                         │
+                             ┌──────────────┐                 │
+                             │   DockApi    │                 │
+                             │ (buffering)  │                 │
+                             │              │   serial_bridge_send_to_uart()
+                             │ sendWsTxt()  │─────────────────┘
+                             └──────┬───────┘
+                                    │
+                                    ▼
+                             ┌──────────────┐
+                             │  WS Client   │
+                             │  (JSON API)  │
+                             └──────────────┘
+```
+
+## WebSocket API Messages
+
+All serial WebSocket commands require an authenticated connection and use the standard
+dock message format with `"type": "dock"`.
+
+### Enable/Disable Serial Events
+
+Subscribe to serial data events for a specific port. Events are delivered only to
+clients that have explicitly enabled them.
+
+Request:
+```json
+{
+  "type": "dock",
+  "command": "enable_serial_events",
+  "port": 1,
+  "enable": true
+}
+```
+
+Response:
+```json
+{
+  "type": "dock",
+  "msg": "enable_serial_events",
+  "code": 200
+}
+```
+
+### Serial Data Event
+
+Sent to subscribed clients when serial data is received. Delivery depends on the
+configured buffering mode:
+
+- **Chunk mode**: Each UART read chunk is sent immediately as a separate event
+- **Line mode**: Data is buffered until the terminator character is received, the
+  buffer is full, or the idle timeout expires
+
+```json
+{
+  "type": "event",
+  "msg": "serial_data",
+  "port": 1,
+  "data": "MV45\r"
+}
+```
+
+The `data` field contains valid UTF-8. Raw bytes 0x80–0xFF are treated as Latin-1
+(ISO-8859-1) and converted to proper UTF-8 encoding. Control characters 0x00–0x1F
+are JSON-escaped by cJSON (`\u00XX`).
+
+### Send Serial Data
+
+Send data to an RS232 port via the UART TX line.
+
+Request:
+```json
+{
+  "type": "dock",
+  "command": "send_serial",
+  "port": 1,
+  "data": "MVUP\r"
+}
+```
+
+Response:
+```json
+{
+  "type": "dock",
+  "msg": "send_serial",
+  "code": 200
+}
+```
+
+Error codes:
+
+- `400` — Invalid port number or missing data field
+- `409` — Port is not configured in RS232 mode
+- `500` — UART write failed
+
+### Configure Serial Buffering
+
+Configure the buffering behavior for WebSocket serial events. All fields are optional;
+omitted fields retain their current value. Configuration is persisted.
+
+Request:
+```json
+{
+  "type": "dock",
+  "command": "set_serial_config",
+  "port": 1,
+  "buffering": "line",
+  "terminator": "\r",
+  "buffer_size": 512,
+  "timeout_ms": 100
+}
+```
+
+| Field         | Type   | Default | Description                              |
+|---------------|--------|---------|------------------------------------------|
+| `port`        | int    | —       | Required. 1-based port number.           |
+| `buffering`   | string | "chunk" | `"chunk"` or `"line"`                    |
+| `terminator`  | string | "\n"    | Single character used as line terminator |
+| `buffer_size` | int    | 512     | Buffer size in bytes (1–16384)           |
+| `timeout_ms`  | int    | 100     | Idle timeout in ms. 0 = no timeout.      |
+
+
+Response:
+```json
+{
+  "type": "dock",
+  "msg": "set_serial_config",
+  "code": 200
+}
+```
+
+Error codes:
+
+- `400` — Invalid port, unknown buffering mode, or buffer_size > 16384
+- `500` — Buffer allocation failed
+
+### Get Serial Configuration
+
+Request:
+```json
+{
+  "type": "dock",
+  "command": "get_serial_config",
+  "port": 1
+}
+```
+
+Response:
+```json
+{
+  "type": "dock",
+  "msg": "get_serial_config",
+  "port": 1,
+  "buffering": "line",
+  "terminator": "\r",
+  "buffer_size": 512,
+  "timeout_ms": 100,
+  "code": 200
+}
+```
+
+## Buffering Modes
+### Chunk Mode
+Every UART read chunk (up to 256 bytes per bridge task iteration) is immediately
+forwarded as a JSON event. No buffering, no interpretation. This provides the lowest
+latency but may split protocol messages across multiple events.
+Suitable for: Binary protocols, custom framing, or when the client handles reassembly.
+
+### Line Mode (default)
+Data is accumulated in a per-port buffer until one of these conditions is met:
+
+1. Terminator character received — Buffer contents (including the terminator) are
+   flushed as a single JSON event
+2. Buffer full — Contents are flushed to prevent data loss
+3. Idle timeout — If no new data arrives within `timeout_ms` after the last byte,
+   the buffer is flushed. This prevents data from being stuck in the buffer indefinitely
+   when a device sends a partial response without a terminator.
+
+Suitable for: AV control protocols (Denon/Marantz `\r`, PJ Link, Sony, etc.)
+
+### Buffer Allocation
+
+- Buffer size < 1024 bytes: Allocated from internal RAM
+- Buffer size >= 1024 bytes: Attempt PSRAM first, fall back to internal RAM
+- Maximum configurable size: 16384 bytes (16 KB)
+
+### Timeout Implementation
+
+The timeout is checked via the bridge task’s idle tick mechanism. Every loop iteration
+(~20ms), the bridge task calls the rx_callback with `data=NULL, len=0`. The DockApi
+handler checks if `timeout_ms` has elapsed since the last received byte and flushes
+if so.
+
+Effective timeout resolution: ~20ms (determined by the bridge task’s select() timeout).
+For a configured 100ms timeout, actual flush occurs between 100–120ms after the last
+byte. This is acceptable for AV control protocol use cases.
+
+## Lifecycle Management
+
+### Bridge Start/Stop
+
+The bridge task is started when a port enters RS232 mode and stopped when the port
+changes to any other mode (IR, trigger, etc.):
+
+Port mode change to RS232:
+  1. ExternalPort::changeMode(RS232) initializes UART driver
+  2. DockApi starts the bridge: serial_bridge_start()
+  3. Bridge task opens TCP server (if enabled) and begins UART processing
+
+Port mode change away from RS232:
+  1. DockApi stops the bridge: serial_bridge_stop()  [synchronous, blocks up to 500ms]
+  2. All TCP clients are disconnected, sockets closed
+  3. ExternalPort::changeMode(new_mode) deinitializes UART driver
+
+The stop-before-deinit ordering prevents race conditions where the bridge task would
+access a destroyed UART driver.
+
+### Runtime TCP Enable/Disable
+TCP servers can be toggled at runtime without restarting the bridge:
+
+set_serial_tcp command:
+  1. Persist new setting via Config
+  2. Stop all running bridges
+  3. Update tcp_enabled flag on each bridge instance
+  4. Restart all bridges that were previously running
+
+## Limitations and Design Notes
+
+1. `No flow control between TCP clients`:  
+   If multiple TCP clients send data concurrently, their bytes may interleave on the UART TX line.
+   The bridge provides no mutual exclusion for senders. This is by design and is typically not a
+   problem for request-response AV protocols.
+
+
+2. `Data loss on slow TCP clients`:  
+   If a TCP client’s send buffer is full (`EAGAIN`/`EWOULDBLOCK`), data destined for that client is dropped.
+   Other clients are unaffected.
+
+
+3. `No binary WebSocket transport`:  
+   The WebSocket API uses JSON with UTF-8 text.  
+   Raw bytes 0x80–0xFF are Latin-1-to-UTF-8 converted. Null bytes (0x00) are
+   JSON-escaped as `\u0000`. For binary-heavy protocols, use the raw TCP interface.
+
+
+4. `Line buffer mutex ordering`:  
+   The lock hierarchy is always `SerialPortBuffer::mutex` → `serial_event_mutex_`.
+   This ordering must be maintained to prevent deadlocks.
+
+
+5. `Idle tick overhead`:  
+   The rx_callback is invoked with NULL data every ~20ms for timeout processing,
+   even when no serial data is flowing. The handler returns immediately if no subscribers
+   are registered or the buffer is empty.
+
+
+6. `UART buffer sizing`:  
+   The UART RX ring buffer is set to 2048 bytes to prevent overflow during TCP passthrough
+   at high baud rates. At 115200 baud, approximately 230 bytes accumulate during a 20ms select()
+   timeout — well within the 2048 byte buffer.

--- a/doc/websocket-api.md
+++ b/doc/websocket-api.md
@@ -201,3 +201,43 @@ Trigger impulse:
 
 - `duration`: time in milliseconds to set output trigger high
 
+## RS232 Communication
+
+Send data:
+```json
+{
+  "type": "dock",
+  "command": "send_serial",
+  "port": 1,
+  "data": "Hello RS232\n"
+}
+```
+
+Enable serial data receive events:
+```json
+{
+  "type": "dock",
+  "command": "enable_serial_events",
+  "port": 1,
+  "enable": true
+}
+```
+
+Serial data event:
+```json
+{
+  "type": "event",
+  "msg": "serial_data",
+  "port": 1,
+  "data": "<RECEIVED_DATA_AS_UTF8>"
+}
+```
+
+Enable TCP serial server:
+```json
+{
+  "type": "dock",
+  "command": "set_serial_tcp",
+  "enable": true
+}
+```

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -24,5 +24,6 @@ idf_component_register(
     infrared
     network
     preferences
+    serial_bridge
     webserver
 )

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -10,7 +10,6 @@
 #include "esp_check.h"
 #include "esp_chip_info.h"
 #include "esp_event.h"
-#include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_system.h"
 #include "esp_timer.h"
@@ -41,6 +40,9 @@ static const int API_FEATURE_FLAG_IR_SEND_HOLD = BIT1;
 
 // Available features.
 static const int API_FEATURE_FLAGS = API_FEATURE_FLAG_IR_REPEAT_NO_RESPONSE | API_FEATURE_FLAG_IR_SEND_HOLD;
+
+static const size_t SERIAL_BUFFER_SIZE_DEFAULT = 512;
+static const size_t SERIAL_BUFFER_SIZE_MAX = 16384;
 
 static const char *const TAG = "API";
 
@@ -207,10 +209,12 @@ DockApi::DockApi(Config *config, WebServer *web, port_map_t ports)
       ports_(ports),
       sockfdSendIR_(-1),
       unauthenticated_fds_mutex_(xSemaphoreCreateMutex()),
-      auth_timer_(nullptr) {
+      auth_timer_(nullptr),
+      serial_event_mutex_(xSemaphoreCreateMutex()) {
     assert(config_);
     assert(web_);
     assert(unauthenticated_fds_mutex_);
+    assert(serial_event_mutex_);
 
     web_->onWsEvent([this](httpd_req_t *req, int sockfd, WsTypeEnum type, uint8_t *payload, size_t length,
                            bool authenticated) -> esp_err_t {
@@ -264,6 +268,12 @@ DockApi::DockApi(Config *config, WebServer *web, port_map_t ports)
                     xSemaphoreGive(unauthenticated_fds_mutex_);
                 }
 
+                // Remove serial event subscriptions for this client
+                if (xSemaphoreTake(serial_event_mutex_, pdMS_TO_TICKS(1000)) == pdTRUE) {
+                    serial_event_fds_.erase(sockfd);
+                    xSemaphoreGive(serial_event_mutex_);
+                }
+
                 return ESP_OK;
             }
             case WS_TEXT:
@@ -283,6 +293,16 @@ DockApi::~DockApi() {
         xTimerStop(auth_timer_, pdMS_TO_TICKS(1000));
     }
     vSemaphoreDelete(unauthenticated_fds_mutex_);
+    vSemaphoreDelete(serial_event_mutex_);
+
+    for (int i = 0; i < EXTERNAL_PORT_COUNT; i++) {
+        if (bridges_[i]) {
+            serial_bridge_destroy(bridges_[i]);
+            bridges_[i] = nullptr;
+        }
+    }
+
+    deinitSerialBuffers();
 }
 
 esp_err_t DockApi::init() {
@@ -300,6 +320,35 @@ esp_err_t DockApi::init() {
         }
         ESP_RETURN_ON_FALSE(xTimerStart(auth_timer_, pdMS_TO_TICKS(3000)), ESP_FAIL, TAG,
                             "Failed to start WS auth timer");
+    }
+
+    // Initialize serial buffer configurations from persistent storage
+    initSerialBuffers();
+
+    // Initialize serial bridge instances
+    bool tcp_enabled = config_->isSerialTcpEnabled();
+
+    for (auto const &[port, ext_port] : ports_) {
+        if (port < 1 || port > EXTERNAL_PORT_COUNT) {
+            continue;
+        }
+
+        serial_bridge_config_t br_cfg = {
+            .port_index = static_cast<uint8_t>(port),
+            .uart_num = ext_port->getUartPort(),
+            .uart_event_queue = ext_port->getUartEventQueue(),
+            .tcp_port = static_cast<uint16_t>(4998 + port),
+            .tcp_enabled = tcp_enabled,
+        };
+        bridges_[port - 1] = serial_bridge_create(&br_cfg);
+
+        if (bridges_[port - 1]) {
+            serial_bridge_set_rx_callback(bridges_[port - 1], serialRxCallback, this);
+
+            if (ext_port->getMode() == RS232) {
+                serial_bridge_start(bridges_[port - 1]);
+            }
+        }
     }
 
     return ESP_OK;
@@ -652,6 +701,14 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         code = processGetPortTrigger(root, responseDoc);
     } else if (command == "set_port_trigger") {
         code = processSetPortTrigger(root);
+    } else if (command == "enable_serial_events") {
+        code = processEnableSerialEvents(sockfd, root);
+    } else if (command == "send_serial") {
+        code = processSendSerial(root);
+    } else if (command == "set_serial_config") {
+        code = processSetSerialConfig(root);
+    } else if (command == "get_serial_config") {
+        code = processGetSerialConfig(root, responseDoc);
     } else if (command == "reboot") {
         ESP_LOGW(TAG, "Rebooting");
         std::string message;
@@ -719,6 +776,29 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         cJSON_AddNumberToObject(responseDoc, "irsend_prio", config_->getIrSendPriority());
         cJSON_AddBoolToObject(responseDoc, "itach_emulation", config_->isGcServerEnabled());
         cJSON_AddBoolToObject(responseDoc, "itach_beacon", config_->isGcServerBeaconEnabled());
+    } else if (command == "set_serial_tcp") {
+        bool ok = false;
+        bool enable = cjson_get_bool(root, "enable", &ok);
+        if (!ok) {
+            code = 400;
+        } else if (config_->enableSerialTcp(enable)) {
+            // Restart all active bridges with new TCP setting
+            for (uint8_t i = 0; i < EXTERNAL_PORT_COUNT; i++) {
+                if (bridges_[i]) {
+                    bool was_running = serial_bridge_is_running(bridges_[i]);
+                    if (was_running) {
+                        serial_bridge_stop(bridges_[i]);
+                    }
+                    serial_bridge_set_tcp_enabled(bridges_[i], enable);
+                    if (was_running) {
+                        serial_bridge_start(bridges_[i]);
+                    }
+                }
+            }
+            code = 200;
+        } else {
+            code = 500;
+        }
     } else {
         code = 400;
         cJSON_AddStringToObject(responseDoc, msgError,
@@ -734,6 +814,387 @@ send_response:
     cJSON_Delete(responseDoc);
     cJSON_Delete(root);
     return ret;
+}
+
+uint16_t DockApi::processEnableSerialEvents(int sockfd, const cJSON *root) {
+    bool    ok = false;
+    uint8_t port = static_cast<uint8_t>(cjson_get_int(root, "port", &ok));
+    if (!ok || port == 0 || port > EXTERNAL_PORT_COUNT) {
+        return 400;
+    }
+
+    bool enable = cjson_get_bool(root, "enable", &ok);
+    if (!ok) {
+        return 400;
+    }
+
+    if (xSemaphoreTake(serial_event_mutex_, pdMS_TO_TICKS(1000)) != pdTRUE) {
+        ESP_LOGE(TAG, "Failed to lock serial event mutex");
+        return 500;
+    }
+
+    uint8_t port_mask = 1 << (port - 1);
+
+    if (enable) {
+        serial_event_fds_[sockfd] |= port_mask;
+        ESP_LOGD(TAG, "WS client %d: serial events enabled for port %d", sockfd, port);
+    } else {
+        if (serial_event_fds_.contains(sockfd)) {
+            serial_event_fds_[sockfd] &= ~port_mask;
+            if (serial_event_fds_[sockfd] == 0) {
+                serial_event_fds_.erase(sockfd);
+            }
+        }
+        ESP_LOGD(TAG, "WS client %d: serial events disabled for port %d", sockfd, port);
+    }
+
+    xSemaphoreGive(serial_event_mutex_);
+    return 200;
+}
+
+uint16_t DockApi::processSendSerial(const cJSON *root) {
+    bool    ok = false;
+    uint8_t port = static_cast<uint8_t>(cjson_get_int(root, "port", &ok));
+    if (!ok || port == 0 || port > EXTERNAL_PORT_COUNT) {
+        return 400;
+    }
+
+    if (!ports_.contains(port)) {
+        return 400;
+    }
+
+    if (ports_[port]->getMode() != RS232) {
+        return 409;
+    }
+
+    const char *data = cjson_get_string(root, "data");
+    if (!data || strlen(data) == 0) {
+        return 400;
+    }
+
+    serial_bridge_t *br = bridges_[port - 1];
+    if (!br) {
+        return 409;
+    }
+
+    esp_err_t ret = serial_bridge_send_to_uart(br, reinterpret_cast<const uint8_t *>(data), strlen(data));
+    if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "send_serial port %d failed: %s", port, esp_err_to_name(ret));
+        return 500;
+    }
+
+    return 200;
+}
+
+uint16_t DockApi::processSetSerialConfig(const cJSON *root) {
+    bool    ok = false;
+    uint8_t port = static_cast<uint8_t>(cjson_get_int(root, "port", &ok));
+    if (!ok || port == 0 || port > EXTERNAL_PORT_COUNT) {
+        return 400;
+    }
+
+    SerialPortBuffer &pbuf = serial_buffers_[port - 1];
+    bool              needs_realloc = false;
+
+    // buffering mode (optional)
+    const char *mode_str = cjson_get_string(root, "buffering");
+    if (mode_str) {
+        if (strcmp(mode_str, "chunk") == 0) {
+            pbuf.mode = SerialPortBuffer::CHUNK;
+        } else if (strcmp(mode_str, "line") == 0) {
+            pbuf.mode = SerialPortBuffer::LINE;
+        } else {
+            return 400;
+        }
+        config_->setSerialBuffering(port, pbuf.mode);
+    }
+
+    // terminator (optional)
+    const char *term_str = cjson_get_string(root, "terminator");
+    if (term_str && strlen(term_str) > 0) {
+        pbuf.terminator = static_cast<uint8_t>(term_str[0]);
+        config_->setSerialTerminatorChar(port, pbuf.terminator);
+    }
+
+    // buffer_size (optional)
+    if (cJSON_HasObjectItem(root, "buffer_size")) {
+        int size = cjson_get_int(root, "buffer_size", &ok);
+        if (!ok || size < 1) {
+            return 400;
+        }
+        if (static_cast<size_t>(size) > SERIAL_BUFFER_SIZE_MAX) {
+            return 400;
+        }
+        if (static_cast<size_t>(size) != pbuf.buffer_size) {
+            pbuf.buffer_size = static_cast<size_t>(size);
+            needs_realloc = true;
+        }
+        config_->setSerialBufferSize(port, static_cast<uint16_t>(size));
+    }
+
+    // timeout_ms (optional)
+    if (cJSON_HasObjectItem(root, "timeout_ms")) {
+        int timeout = cjson_get_int(root, "timeout_ms", &ok);
+        if (!ok || timeout < 0) {
+            return 400;
+        }
+        pbuf.timeout_ms = static_cast<uint32_t>(timeout);
+        config_->setSerialTimeout(port, static_cast<uint16_t>(timeout));
+    }
+
+    // Reallocate buffer if size changed
+    if (needs_realloc) {
+        if (xSemaphoreTake(pbuf.mutex, pdMS_TO_TICKS(1000)) == pdTRUE) {
+            // Flush any pending data before realloc
+            if (pbuf.len > 0) {
+                flushSerialBuffer(port, pbuf);
+            }
+            pbuf.deallocate();
+            if (!pbuf.allocate()) {
+                xSemaphoreGive(pbuf.mutex);
+                return 500;
+            }
+            xSemaphoreGive(pbuf.mutex);
+        } else {
+            return 500;
+        }
+    }
+
+    return 200;
+}
+
+uint16_t DockApi::processGetSerialConfig(const cJSON *root, cJSON *responseDoc) {
+    bool    ok = false;
+    uint8_t port = static_cast<uint8_t>(cjson_get_int(root, "port", &ok));
+    if (!ok || port == 0 || port > EXTERNAL_PORT_COUNT) {
+        return 400;
+    }
+
+    SerialPortBuffer &pbuf = serial_buffers_[port - 1];
+
+    cJSON_AddNumberToObject(responseDoc, "port", port);
+    cJSON_AddStringToObject(responseDoc, "buffering", pbuf.mode == SerialPortBuffer::LINE ? "line" : "chunk");
+
+    // Represent terminator as the escaped character
+    char term_buf[2] = {static_cast<char>(pbuf.terminator), '\0'};
+    cJSON_AddStringToObject(responseDoc, "terminator", term_buf);
+
+    cJSON_AddNumberToObject(responseDoc, "buffer_size", pbuf.buffer_size);
+    cJSON_AddNumberToObject(responseDoc, "timeout_ms", pbuf.timeout_ms);
+
+    return 200;
+}
+
+void DockApi::serialRxCallback(uint8_t port_index, const uint8_t *data, size_t len, void *user_ctx) {
+    auto *that = static_cast<DockApi *>(user_ctx);
+    that->handleSerialRx(port_index, data, len);
+}
+
+void DockApi::handleSerialRx(uint8_t port_index, const uint8_t *data, size_t len) {
+    if (port_index < 1 || port_index > EXTERNAL_PORT_COUNT) {
+        return;
+    }
+
+    SerialPortBuffer &pbuf = serial_buffers_[port_index - 1];
+
+    // Fast path: check if anyone is subscribed
+    // Mutex discipline:
+    // - The pbuf.mutex is held in line mode while data is being written to the buffer.
+    // - flushSerialBuffer is called within the mutex and then acquires the serial_event_mutex_ again.
+    // - The lock order is always: pbuf.mutex → serial_event_mutex_.
+    // As long as this remains consistent (never the other way around), there is no deadlock.
+    if (xSemaphoreTake(serial_event_mutex_, pdMS_TO_TICKS(10)) != pdTRUE) {
+        return;
+    }
+    bool    has_subscribers = false;
+    uint8_t port_mask = 1 << (port_index - 1);
+    for (auto const &[fd, mask] : serial_event_fds_) {
+        if (mask & port_mask) {
+            has_subscribers = true;
+            break;
+        }
+    }
+    xSemaphoreGive(serial_event_mutex_);
+
+    if (!has_subscribers) {
+        // No subscribers: discard any buffered data and skip processing
+        if (pbuf.len > 0) {
+            if (xSemaphoreTake(pbuf.mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+                pbuf.reset();
+                xSemaphoreGive(pbuf.mutex);
+            }
+        }
+        return;
+    }
+
+    // Idle tick (data == NULL): check timeout
+    if (data == NULL || len == 0) {
+        if (pbuf.mode == SerialPortBuffer::LINE && pbuf.len > 0 && pbuf.timeout_ms > 0) {
+            if (xSemaphoreTake(pbuf.mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+                if (pbuf.len > 0 && pbuf.last_rx_us > 0) {
+                    int64_t now_us = esp_timer_get_time();
+                    int64_t elapsed_ms = (now_us - pbuf.last_rx_us) / 1000;
+                    if (elapsed_ms >= pbuf.timeout_ms) {
+                        flushSerialBuffer(port_index, pbuf);
+                    }
+                }
+                xSemaphoreGive(pbuf.mutex);
+            }
+        }
+        return;
+    }
+
+    // Data received
+    if (pbuf.mode == SerialPortBuffer::CHUNK) {
+        // Chunk mode: send immediately, no buffering
+        sendSerialEvent(port_index, data, len);
+        return;
+    }
+
+    // Line mode: buffer until terminator or buffer full
+    if (xSemaphoreTake(pbuf.mutex, pdMS_TO_TICKS(50)) != pdTRUE) {
+        return;
+    }
+
+    for (size_t i = 0; i < len; i++) {
+        if (pbuf.buf && pbuf.len < pbuf.buffer_size) {
+            pbuf.buf[pbuf.len++] = data[i];
+            pbuf.last_rx_us = esp_timer_get_time();
+        }
+
+        // Check for terminator
+        if (data[i] == pbuf.terminator) {
+            flushSerialBuffer(port_index, pbuf);
+        }
+        // Check for buffer full
+        else if (pbuf.len >= pbuf.buffer_size) {
+            flushSerialBuffer(port_index, pbuf);
+        }
+    }
+
+    xSemaphoreGive(pbuf.mutex);
+}
+
+void DockApi::flushSerialBuffer(uint8_t port_index, SerialPortBuffer &pbuf) {
+    if (pbuf.len == 0) {
+        return;
+    }
+
+    sendSerialEvent(port_index, pbuf.buf, pbuf.len);
+    pbuf.len = 0;
+    pbuf.last_rx_us = 0;
+}
+
+void DockApi::sendSerialEvent(uint8_t port_index, const uint8_t *data, size_t len) {
+    // Collect subscribed fds for this port
+    // Note: using std::vector for simplicity, assuming there won't be many subscribers.
+    // With multiple subscribers and high UART datarates, a static array of fixed size should be used.
+    if (xSemaphoreTake(serial_event_mutex_, pdMS_TO_TICKS(50)) != pdTRUE) {
+        return;
+    }
+
+    uint8_t          port_mask = 1 << (port_index - 1);
+    std::vector<int> subscribed_fds;
+    subscribed_fds.reserve(serial_event_fds_.size());
+
+    for (auto const &[fd, mask] : serial_event_fds_) {
+        if (mask & port_mask) {
+            subscribed_fds.push_back(fd);
+        }
+    }
+
+    xSemaphoreGive(serial_event_mutex_);
+
+    if (subscribed_fds.empty()) {
+        return;
+    }
+
+    // Convert Latin-1 to UTF-8
+    // Worst case: every byte becomes 2-byte UTF-8
+    size_t utf8_buf_size = len * 2 + 1;
+    char  *utf8_buf = static_cast<char *>(malloc(utf8_buf_size));
+    if (!utf8_buf) {
+        return;
+    }
+    latin1_to_utf8(data, len, utf8_buf, utf8_buf_size);
+
+    // Build JSON event
+    cJSON *event = cJSON_CreateObject();
+    if (!event) {
+        free(utf8_buf);
+        return;
+    }
+
+    cJSON_AddStringToObject(event, "type", "event");
+    cJSON_AddStringToObject(event, "msg", "serial_data");
+    cJSON_AddNumberToObject(event, "port", port_index);
+    cJSON_AddStringToObject(event, "data", utf8_buf);
+
+    free(utf8_buf);
+
+    char *msg = cJSON_PrintUnformatted(event);
+    cJSON_Delete(event);
+
+    if (!msg) {
+        return;
+    }
+
+    for (int fd : subscribed_fds) {
+        // Important: needs to be const char* to avoid freeing the buffer in sendWsTxt!
+        web_->sendWsTxt(fd, (const char *)msg);
+    }
+
+    cJSON_free(msg);
+}
+
+void DockApi::initSerialBuffers() {
+    for (uint8_t i = 0; i < EXTERNAL_PORT_COUNT; i++) {
+        loadSerialBufferConfig(i + 1);
+        serial_buffers_[i].allocate();
+    }
+}
+
+void DockApi::deinitSerialBuffers() {
+    for (uint8_t i = 0; i < EXTERNAL_PORT_COUNT; i++) {
+        if (serial_buffers_[i].mutex) {
+            vSemaphoreDelete(serial_buffers_[i].mutex);
+            serial_buffers_[i].mutex = nullptr;
+        }
+        serial_buffers_[i].deallocate();
+    }
+}
+
+void DockApi::loadSerialBufferConfig(uint8_t port) {
+    if (port < 1 || port > EXTERNAL_PORT_COUNT) return;
+
+    SerialPortBuffer &pbuf = serial_buffers_[port - 1];
+
+    // Load from persistent config
+    uint8_t mode = config_->getSerialBuffering(port);
+    if (mode == 1) {
+        pbuf.mode = SerialPortBuffer::CHUNK;
+    } else {
+        pbuf.mode = SerialPortBuffer::LINE;
+    }
+
+    uint8_t term = config_->getSerialTerminatorChar(port);
+    if (term != 0) {
+        pbuf.terminator = term;
+    } else {
+        pbuf.terminator = '\n';
+    }
+
+    uint16_t buf_size = config_->getSerialBufferSize(port);
+    if (buf_size == 0) {
+        pbuf.buffer_size = SERIAL_BUFFER_SIZE_DEFAULT;
+    } else if (buf_size > SERIAL_BUFFER_SIZE_MAX) {
+        pbuf.buffer_size = SERIAL_BUFFER_SIZE_MAX;
+    } else {
+        pbuf.buffer_size = buf_size;
+    }
+
+    uint16_t timeout = config_->getSerialTimeout(port);
+    pbuf.timeout_ms = (timeout == 0) ? 100 : timeout;
 }
 
 uint16_t DockApi::processGetPortModes(cJSON *responseDoc) {
@@ -813,6 +1274,11 @@ uint16_t DockApi::processSetPortMode(const cJSON *root) {
         return 503;
     }
 
+    // Stop serial bridge before mode change (prevents race with UART deinit)
+    if (ports_[port]->getMode() == RS232 && bridges_[port - 1]) {
+        serial_bridge_stop(bridges_[port - 1]);
+    }
+
     if (mode == RS232) {
         cJSON *uart = cJSON_GetObjectItem(root, "uart");
         if (!cJSON_IsObject(uart)) {
@@ -839,6 +1305,11 @@ uint16_t DockApi::processSetPortMode(const cJSON *root) {
     switch (ret) {
         case ESP_OK:
             config_->setExternalPortMode(port, mode);
+            // Start bridge if switched to RS232
+            if (mode == RS232 && bridges_[port - 1]) {
+                serial_bridge_set_uart_queue(bridges_[port - 1], ports_[port]->getUartEventQueue());
+                serial_bridge_start(bridges_[port - 1]);
+            }
             return 200;
         case ESP_ERR_NOT_SUPPORTED:
             return 400;
@@ -929,6 +1400,19 @@ void DockApi::dockEventHandler(void *arg, esp_event_base_t event_base, int32_t e
             if (!mode || mode->port > EXTERNAL_PORT_COUNT || !that->ports_.contains(mode->port)) {
                 ESP_LOGE(TAG, "%s:%ld: invalid port", event_base, event_id);
                 return;
+            }
+
+            // Sync serial bridge state for external mode changes (e.g. auto-detect at boot)
+            if (mode->port >= 1 && mode->port <= EXTERNAL_PORT_COUNT && mode->state == ESP_OK) {
+                serial_bridge_t *br = that->bridges_[mode->port - 1];
+                if (br) {
+                    if (mode->active_mode == RS232) {
+                        serial_bridge_set_uart_queue(br, that->ports_[mode->port]->getUartEventQueue());
+                        serial_bridge_start(br);
+                    } else {
+                        serial_bridge_stop(br);
+                    }
+                }
             }
 
             cJSON *responseDoc = cJSON_CreateObject();

--- a/main/ucd_api.h
+++ b/main/ucd_api.h
@@ -9,14 +9,18 @@
 #include <map>
 #include <string>
 
+#include "esp_heap_caps.h"
 #include "esp_http_server.h"
 #include "freertos/task.h"
 #include "freertos/timers.h"
 
 #include "WebServer.h"
+#include "board.h"
 #include "cJSON.h"
 #include "config.h"
 #include "external_port.h"
+#include "serial_bridge.h"
+#include "serial_port_buffer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -62,6 +66,20 @@ class DockApi {
     static void authTimeoutCallback(TimerHandle_t timer_id);
     void        checkAuthTimeouts();
 
+    uint16_t processEnableSerialEvents(int sockfd, const cJSON* root);
+    uint16_t processSendSerial(const cJSON* root);
+    uint16_t processSetSerialConfig(const cJSON* root);
+    uint16_t processGetSerialConfig(const cJSON* root, cJSON* responseDoc);
+
+    static void serialRxCallback(uint8_t port_index, const uint8_t* data, size_t len, void* user_ctx);
+    void        handleSerialRx(uint8_t port_index, const uint8_t* data, size_t len);
+    void        flushSerialBuffer(uint8_t port_index, SerialPortBuffer& pbuf);
+    void        sendSerialEvent(uint8_t port_index, const uint8_t* data, size_t len);
+
+    void initSerialBuffers();
+    void deinitSerialBuffers();
+    void loadSerialBufferConfig(uint8_t port);
+
     Config*    config_;
     WebServer* web_;
     port_map_t ports_;
@@ -70,4 +88,11 @@ class DockApi {
     std::map<int, uint64_t> unauthenticated_fds_;
     SemaphoreHandle_t       unauthenticated_fds_mutex_;
     TimerHandle_t           auth_timer_;
+
+    serial_bridge_t* bridges_[EXTERNAL_PORT_COUNT] = {};
+    SerialPortBuffer serial_buffers_[EXTERNAL_PORT_COUNT];
+
+    // Per-client serial event subscriptions: sockfd -> port bitmask (bit 0 = port 1, bit 1 = port 2)
+    std::map<int, uint8_t> serial_event_fds_;
+    SemaphoreHandle_t      serial_event_mutex_;
 };


### PR DESCRIPTION
Add a serial bridge component that provides bidirectional RS232-to-network bridging for the configurable external ports when operating in RS232 mode.

### Features

- Optional raw TCP server per port (GlobalCache iTach-compatible, ports 4999/5000)
- Up to 8 simultaneous TCP clients per port with broadcast on UART RX
- WebSocket JSON API for serial data send/receive with per-client event subscription
- Configurable buffering modes: immediate chunk forwarding or line-based with
  terminator detection and idle timeout
- Latin-1 to UTF-8 conversion for safe JSON transport
- Task watchdog integration for 24/7 reliability
- TCP servers globally enable/disable at runtime

### New WebSocket Commands

- `enable_serial_events` — Subscribe/unsubscribe to serial data events per port
- `send_serial` — Send data to an RS232 port
- `set_serial_config` / `get_serial_config` — Configure buffering mode, terminator, buffer size, and idle timeout (persisted)

### Architecture

One FreeRTOS task per port (Core 0, priority 5), using non-blocking sockets with `select()` and IDF UART event queue. See `doc/serial-bridge.md` for detailed documentation including data flow diagrams, design decisions, and limitations.

### Changes

- **New:** `components/serial_bridge/` — Bridge component (serial_bridge, serial_port_buffer)
- **Modified:** `external_port.h/.cpp` — Added `getUartEventQueue()`, `getUartPort()` getters; increased UART RX buffer to 2048
- **Modified:** `ucd_api.h/.cpp` — Bridge lifecycle management, serial WS commands, buffering logic
- **New:** `doc/serial-bridge.md` — Technical documentation

LLM disclaimer: assisted with Claude, manually verified and refined

Closes #4 