### PR TITLE
feat: Add log router with WebSocket streaming support

### DIFF
--- a/components/log_router/CMakeLists.txt
+++ b/components/log_router/CMakeLists.txt
@@ -1,0 +1,6 @@
+idf_component_register(
+    SRCS "log_router.c"
+    INCLUDE_DIRS "include"
+    REQUIRES
+    log
+)

--- a/components/log_router/include/log_router.h
+++ b/components/log_router/include/log_router.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Unfolded Circle ApS and/or its affiliates <hello@unfoldedcircle.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <stdint.h>
+
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_log_level.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Callback function type for sending log messages to external destinations
+ *
+ * @param tag Log tag
+ * @param level Log level
+ * @param message Full log message (includes timestamp, level, tag, text)
+ * @param len Length of the message
+ * @param ctx User context
+ * @return esp_err_t ESP_OK on success
+ */
+typedef esp_err_t (*log_output_callback_t)(const char *tag, esp_log_level_t level, const char *message, size_t len,
+                                           void *ctx);
+
+/**
+ * @brief Initialize the log router
+ *
+ * This sets up a custom log writer that forwards all ESP_LOG* messages to
+ * registered output callbacks while keeping the default console output active.
+ *
+ * @return esp_err_t ESP_OK on success
+ */
+esp_err_t log_router_init(void);
+
+/**
+ * @brief Register a callback for log output (e.g., WebSocket)
+ *
+ * Multiple callbacks can be registered. Each will receive all log messages.
+ *
+ * @param callback Callback function (NULL to unregister)
+ * @param ctx User context passed to callback
+ * @param callback_id Output parameter to store the callback ID for later removal
+ * @return esp_err_t ESP_OK on success, ESP_ERR_NO_MEM if max callbacks reached
+ */
+esp_err_t log_router_register_callback(log_output_callback_t callback, void *ctx, int *callback_id);
+
+/**
+ * @brief Unregister a previously registered callback
+ *
+ * @param callback_id ID returned from log_router_register_callback
+ * @return esp_err_t ESP_OK on success, ESP_ERR_NOT_FOUND if ID not found
+ */
+esp_err_t log_router_unregister_callback(int callback_id);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/log_router/log_router.c
+++ b/components/log_router/log_router.c
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Unfolded Circle ApS and/or its affiliates <hello@unfoldedcircle.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "log_router.h"
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "esp_log.h"
+
+static const char *TAG = "LOG_ROUTER";
+
+// Maximum number of log output callbacks. At the moment we only have the UC WS API.
+#define MAX_LOG_CALLBACKS 1
+
+// Maximum length of formatted log message. Note: we are not using long log messages, 256 should be plenty
+#define MAX_LOG_LEN 256
+
+// Callback entry structure
+typedef struct {
+    int                   id;
+    log_output_callback_t callback;
+    void                 *ctx;
+    bool                  active;
+} log_callback_entry_t;
+
+// Static storage for callbacks
+static log_callback_entry_t s_callbacks[MAX_LOG_CALLBACKS];
+static int                  s_next_id = 1;
+static bool                 s_initialized = false;
+
+// Original vprintf function (outputs to console/UART)
+static int (*g_original_vprintf)(const char *fmt, va_list args) = NULL;
+
+// Helper to parse log message and extract tag/level
+static void parse_log_message(const char *message, size_t len, char *tag, size_t tag_size, esp_log_level_t *level) {
+    tag[0] = '\0';
+    *level = ESP_LOG_INFO;
+
+    if (len < 10) {
+        return;
+    }
+
+    // Extract level (first character)
+    switch (message[0]) {
+        case 'E':
+            *level = ESP_LOG_ERROR;
+            break;
+        case 'W':
+            *level = ESP_LOG_WARN;
+            break;
+        case 'I':
+            *level = ESP_LOG_INFO;
+            break;
+        case 'D':
+            *level = ESP_LOG_DEBUG;
+            break;
+        case 'V':
+            *level = ESP_LOG_VERBOSE;
+            break;
+        default:
+            *level = ESP_LOG_INFO;
+            break;
+    }
+
+    // Find tag between ") " and ":"
+    const char *tag_start = strchr(message, ')');
+    if (tag_start) {
+        tag_start++;
+        while (*tag_start == ' ' && tag_start < message + len) tag_start++;
+
+        const char *tag_end = strchr(tag_start, ':');
+        if (tag_end && (tag_end - tag_start < (ptrdiff_t)tag_size)) {
+            size_t tag_len = tag_end - tag_start;
+            if (tag_len >= tag_size) {
+                tag_len = tag_size - 1;
+            }
+            strncpy(tag, tag_start, tag_len);
+            tag[tag_len] = '\0';
+        }
+    }
+}
+
+// Helper to check if any callbacks are active (fast path check)
+static inline bool has_active_callbacks(void) {
+    // Quick check: if next_id is still 1, no callbacks were ever registered
+    if (s_next_id == 1) {
+        return false;
+    }
+
+    // Check if any callback is currently active
+    for (int i = 0; i < MAX_LOG_CALLBACKS; i++) {
+        if (s_callbacks[i].active) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Custom vprintf function that forwards to multiple outputs
+static int log_router_vprintf(const char *fmt, va_list args) {
+    // Always output to console (original vprintf) - this is the common case
+    int ret = 0;
+    if (g_original_vprintf) {
+        va_list args_copy;
+        va_copy(args_copy, args);
+        ret = g_original_vprintf(fmt, args_copy);
+        va_end(args_copy);
+    }
+
+    // FAST PATH: Skip all callback logic if no subscribers active
+    // This is the most common case - no extra log clients
+    if (!has_active_callbacks()) {
+        return ret;
+    }
+
+    // SLOW PATH: Only execute when callbacks are registered
+    // Format the message into a buffer for callbacks (don't use a static buffer for thread safety)
+    char    log_buffer[MAX_LOG_LEN];
+    va_list args_copy2;
+    va_copy(args_copy2, args);
+    int len = vsnprintf(log_buffer, sizeof(log_buffer), fmt, args_copy2);
+    va_end(args_copy2);
+
+    if (len <= 0) {
+        return ret;
+    }
+
+    // Ensure null termination
+    if (len >= (int)sizeof(log_buffer)) {
+        len = sizeof(log_buffer) - 1;
+    }
+    log_buffer[len] = '\0';
+
+    // Parse the message to extract tag and level
+    char            tag[32] = {0};
+    esp_log_level_t level = ESP_LOG_INFO;
+
+    parse_log_message(log_buffer, len, tag, sizeof(tag), &level);
+
+    // Forward to all registered callbacks
+    for (int i = 0; i < MAX_LOG_CALLBACKS; i++) {
+        if (s_callbacks[i].active && s_callbacks[i].callback) {
+            s_callbacks[i].callback(tag, level, log_buffer, len, s_callbacks[i].ctx);
+        }
+    }
+
+    return ret;
+}
+
+esp_err_t log_router_init(void) {
+    if (s_initialized) {
+        return ESP_OK;
+    }
+
+    memset(s_callbacks, 0, sizeof(s_callbacks));
+    s_next_id = 1;
+
+    // Store the original vprintf function (default outputs to UART/console)
+    g_original_vprintf = esp_log_set_vprintf(log_router_vprintf);
+
+    s_initialized = true;
+    ESP_LOGI(TAG, "Log router initialized");
+
+    return ESP_OK;
+}
+
+esp_err_t log_router_register_callback(log_output_callback_t callback, void *ctx, int *callback_id) {
+    if (!s_initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (!callback) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    for (int i = 0; i < MAX_LOG_CALLBACKS; i++) {
+        if (!s_callbacks[i].active) {
+            s_callbacks[i].id = s_next_id++;
+            s_callbacks[i].callback = callback;
+            s_callbacks[i].ctx = ctx;
+            s_callbacks[i].active = true;
+
+            if (callback_id) {
+                *callback_id = s_callbacks[i].id;
+            }
+
+            ESP_LOGD(TAG, "Callback registered with ID %d", s_callbacks[i].id);
+            return ESP_OK;
+        }
+    }
+
+    ESP_LOGE(TAG, "Maximum number of callbacks reached (%d)", MAX_LOG_CALLBACKS);
+    return ESP_ERR_NO_MEM;
+}
+
+esp_err_t log_router_unregister_callback(int callback_id) {
+    if (!s_initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    for (int i = 0; i < MAX_LOG_CALLBACKS; i++) {
+        if (s_callbacks[i].active && s_callbacks[i].id == callback_id) {
+            s_callbacks[i].active = false;
+            s_callbacks[i].callback = NULL;
+            s_callbacks[i].ctx = NULL;
+
+            ESP_LOGD(TAG, "Callback %d unregistered", callback_id);
+            return ESP_OK;
+        }
+    }
+
+    return ESP_ERR_NOT_FOUND;
+}

--- a/doc/log-router.md
+++ b/doc/log-router.md
@@ -1,0 +1,516 @@
+# Log Router
+
+## Overview
+
+The Log Router is a lightweight logging infrastructure component that intercepts ESP-IDF log messages and forwards them
+to multiple output destinations while preserving the default console/UART output. It was designed specifically for the
+ESP32-S3 Dock 3 firmware to enable real-time log streaming to WebSocket clients.
+
+**Primary Use Case:** Real-time debugging and monitoring via WebSocket API or the upcoming web management UI without
+compromising serial console output.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    ESP_LOG* Macros                          │
+│              (ESP_LOGI, ESP_LOGE, ESP_LOGD, etc.)           │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│                  esp_log_set_vprintf()                      │
+│              (Intercepts all log output)                    │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│                  log_router_vprintf()                       │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │ FAST PATH (99%+ of runtime):                          │  │
+│  │ - Check has_active_callbacks()                        │  │
+│  │ - If false: return immediately                        │  │
+│  │ - Overhead: single integer comparison                 │  │
+│  └───────────────────────────────────────────────────────┘  │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │ SLOW PATH (when subscribers active):                  │  │
+│  │ - Format message to buffer                            │  │
+│  │ - Parse tag and level                                 │  │
+│  │ - Forward to all registered callbacks                 │  │
+│  └───────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+                            │
+            ┌───────────────┴───────────────┐
+            │                               │
+            ▼                               ▼
+┌───────────────────────┐       ┌───────────────────────┐
+│  Original vprintf     │       │  Registered Callbacks │
+│  (Console/UART)       │       │  - WebSocket (DockApi)│
+│  ALWAYS ACTIVE        │       │  - Syslog (future)    │
+└───────────────────────┘       └───────────────────────┘
+```
+
+## Component Structure
+
+```
+components/
+└── log_router/
+    ├── CMakeLists.txt
+    ├── include/
+    │   └── log_router.h
+    └── log_router.c
+```
+
+### Files
+
+| File             | Purpose                                         | Language |
+|------------------|-------------------------------------------------|----------|
+| `log_router.h`   | Public API header with callback type definition | C        |
+| `log_router.c`   | Implementation with vprintf interception        | C        |
+| `CMakeLists.txt` | ESP-IDF component registration                  | CMake    |
+
+## Public API
+
+### Type Definitions
+
+```c
+typedef esp_err_t (*log_output_callback_t)(
+    const char *tag, 
+    esp_log_level_t level, 
+    const char *message, 
+    size_t len,
+    void *ctx
+);
+```
+
+**Callback Parameters:**
+
+- `tag`: Extracted log tag (e.g., "wifi", "API", "CHARGE")
+- `level`: ESP log level (ESP_LOG_ERROR, ESP_LOG_WARN, etc.)
+- `message`: Full formatted log message including timestamp, level, tag, and log
+- `len`: Length of the message string
+- `ctx`: User context pointer passed during registration
+
+**Return:** `ESP_OK` on success
+
+### Functions
+
+#### `log_router_init()`
+
+```c
+esp_err_t log_router_init(void);
+```
+
+Initializes the log router by intercepting ESP-IDF's vprintf function. Must be called before registering callbacks.
+
+**Returns:**
+
+- `ESP_OK`: Success
+- Error: Initialization failed
+
+**Side Effects:**
+
+- Calls `esp_log_set_vprintf()` to intercept all log output
+- Original vprintf is preserved and always called (console output never lost)
+
+#### `log_router_register_callback()`
+
+```c
+esp_err_t log_router_register_callback(
+    log_output_callback_t callback, 
+    void *ctx, 
+    int *callback_id
+);
+```
+
+Registers a callback to receive all log messages.
+
+**Parameters:**
+
+- `callback`: Function pointer to receive log messages (required, cannot be NULL)
+- `ctx`: User context passed to callback on each invocation
+- `callback_id`: Output parameter to store callback ID for later unregistration
+
+**Returns:**
+
+- `ESP_OK`: Success
+- `ESP_ERR_INVALID_STATE`: Log router not initialized
+- `ESP_ERR_INVALID_ARG`: Callback is NULL
+- `ESP_ERR_NO_MEM`: Maximum callbacks reached (MAX_LOG_CALLBACKS)
+
+**Example:**
+
+```c
+int callback_id;
+log_router_register_callback(my_callback, my_context, &callback_id);
+```
+
+#### `log_router_unregister_callback()`
+
+```c
+esp_err_t log_router_unregister_callback(int callback_id);
+```
+
+Unregisters a previously registered callback.
+
+**Parameters:**
+
+- `callback_id`: ID returned from `log_router_register_callback()`
+
+**Returns:**
+
+- `ESP_OK`: Success
+- `ESP_ERR_INVALID_STATE`: Log router not initialized
+- `ESP_ERR_NOT_FOUND`: Callback ID not found
+
+## Design Decisions
+
+### vprintf Interception via `esp_log_set_vprintf()`
+
+**Rationale:**
+
+- IDF `ESP_LOG*` functions are used in the project
+- `esp_log_set_vprintf()` is used in ESP-IDF 5.x API
+- Returns original vprintf function pointer for chaining
+- Minimal overhead when properly optimized
+
+### Fast Path Optimization
+
+**Decision:** Implement early-exit fast path when no callbacks are active.
+
+**Rationale:**
+
+- Log streaming is inactive 99%+ of runtime
+- Every log call incurs overhead only when subscribers exist
+- Critical for embedded system with limited CPU resources
+
+### Console Output Always Active
+
+**Decision:** Original vprintf is always called, console output cannot be disabled.
+
+**Rationale:**
+
+- Serial console is critical for debugging and recovery
+- Log router is additive, not replacement
+- Prevents accidental loss of console access
+
+### Callback Execution in Logging Context
+
+**Decision:** Callbacks execute synchronously within the vprintf call.
+
+**Rationale:**
+
+- Simpler implementation
+- No queue management overhead
+- WebSocket sending is already async (httpd work queue)
+
+**Trade-offs:**
+
+- **Pro:** No buffer management, no message loss due to queue overflow
+- **Con:** Blocking if callback is slow
+
+**Mitigation:** `DockApi::sendLogToSubscribers()` uses non-blocking mutex take with timeout.
+
+**Future Improvement:** If performance becomes an issue, implement a FreeRTOS queue or ring-buffer with a dedicated
+sender task.
+
+### Message Parsing in Router
+
+**Decision:** Log router parses messages to extract tag and level, not just forward raw text.
+
+**Rationale:**
+
+- Callbacks receive structured metadata (tag, level) without re-parsing
+- Enables filtering by tag or level in callbacks
+- Consistent parsing logic across all callbacks
+
+**Parsed Format:** `<LEVEL> (<TIMESTAMP>) <TAG>: <TEXT>`
+
+**Example:** `I (273131) CHARGE: 0 mV`
+
+- Level: `ESP_LOG_INFO`
+- Timestamp: `273131` ms
+- Tag: `CHARGE`
+- Text: `0 mV`
+
+## WebSocket Log Streaming Integration
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    DockApi (ucd_api.cpp)                    │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │ log_callback_id_                                      │  │
+│  │ log_subscribers_ (std::set<int>)                      │  │
+│  │ log_subscribers_mutex_                                │  │
+│  └───────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+         │
+         │ log_router_register_callback(logCallback, this, &id)
+         ▼
+┌─────────────────────────────────────────────────────────────┐
+│                   Log Router                                │
+│  Forwards all ESP_LOG* messages to logCallback()            │
+└─────────────────────────────────────────────────────────────┘
+         │
+         │ Callback invokes sendLogToSubscribers()
+         ▼
+┌─────────────────────────────────────────────────────────────┐
+│              sendLogToSubscribers()                         │
+│  - Parse timestamp from message                             │
+│  - Trim whitespace from text                                │
+│  - Build JSON with cJSON (auto-escaping)                    │
+│  - Send to all subscribers via WebServer::sendWsTxt()       │
+└─────────────────────────────────────────────────────────────┘
+         │
+         │ Async send via httpd work queue
+         ▼
+┌─────────────────────────────────────────────────────────────┐
+│              WebSocket Clients                              │
+│  Receive: {"type":"event","msg":"log","level":"I",...}      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Subscription Management
+
+**Data Structures in `DockApi`:**
+
+```c
+std::set<int> log_subscribers_;           // WebSocket socket FDs
+SemaphoreHandle_t log_subscribers_mutex_; // Protects subscriber set
+int log_callback_id_;                     // Log router callback ID
+```
+
+**Lifecycle:**
+
+1. **Constructor:** Initialize log router, register callback
+2. **Client connects:** Not yet subscribed
+3. **Client sends `enable_log_events: true`:** Add to `log_subscribers_`
+4. **Client sends `enable_log_events: false`:** Remove from `log_subscribers_`
+5. **Client disconnects:** Automatically removed in `WS_DISCONNECTED` handler
+6. **Destructor:** Unregister callback, delete mutex
+
+### WebSocket API
+
+#### Subscribe to Log Streaming
+
+**Request:**
+
+```json
+{
+  "type": "dock",
+  "command": "enable_log_events",
+  "enable": true
+}
+```
+
+**Response:**
+
+```json
+{
+  "type": "dock",
+  "command": "enable_log_events",
+  "enable": true,
+  "code": 200
+}
+```
+
+#### Unsubscribe from Log Streaming
+
+**Request:**
+
+```json
+{
+  "type": "dock",
+  "command": "enable_log_events",
+  "enable": false
+}
+```
+
+**Response:**
+
+```json
+{
+  "type": "dock",
+  "command": "enable_log_events",
+  "enable": false,
+  "code": 200
+}
+```
+
+---
+
+### Log Event Message Format
+
+**JSON Structure:**
+
+```json
+{
+  "type": "event",
+  "msg": "log",
+  "level": "I",
+  "tag": "CHARGE",
+  "ts": 273131,
+  "log": "0 mV"
+}
+```
+
+**Fields:**
+
+| Field   | Type   | Description                           | Example                           |
+|---------|--------|---------------------------------------|-----------------------------------|
+| `type`  | string | Always `"event"`                      | `"event"`                         |
+| `msg`   | string | Event type, always `"log"`            | `"log"`                           |
+| `level` | string | Log level character                   | `"I"`, `"E"`, `"W"`, `"D"`, `"V"` |
+| `tag`   | string | Log tag extracted from message        | `"CHARGE"`, `"wifi"`, `"API"`     |
+| `ts`    | number | Timestamp in milliseconds from boot   | `273131`                          |
+| `log`   | string | Log message text (trimmed, no prefix) | `"0 mV"`                          |
+
+**Level Characters:**
+
+- `E`: ESP_LOG_ERROR
+- `W`: ESP_LOG_WARN
+- `I`: ESP_LOG_INFO
+- `D`: ESP_LOG_DEBUG
+- `V`: ESP_LOG_VERBOSE
+
+### Message Processing Details
+
+#### Parsing
+
+**Input Format:** `<LEVEL> (<TIMESTAMP>) <TAG>: <TEXT>`
+
+**Example:** `I (273131) CHARGE: 0 mV`
+
+**Parsing Steps:**
+
+1. Find timestamp between `(` and `)`
+2. Convert to integer with `strtoul()`
+3. Find text after first `:` following timestamp
+4. Skip leading spaces after `:`
+5. Trim leading whitespace (space, tab, CR, LF)
+6. Trim trailing whitespace (space, tab, CR, LF)
+7. Truncate to 500 characters max
+
+#### JSON Escaping
+
+**Decision:** No manual JSON escaping required.
+
+**Rationale:** cJSON automatically escapes special characters when serializing:
+
+- `"` → `\"`
+- `\` → `\\`
+- Control characters → `\uXXXX` or escaped sequences
+
+**Note:** Newlines, tabs, and carriage returns within text are preserved (not replaced with spaces) to maintain original
+log message integrity.
+
+## Performance Considerations
+
+### Fast Path (No Subscribers)
+
+**Overhead per log call:**
+
+- 1 integer comparison: `s_next_id == 1`
+- No memory operations
+- No string formatting
+- No callback dispatch
+
+**Impact:** Negligible (< 1% CPU overhead)
+
+### Slow Path (Subscribers Active)
+
+**Overhead per log call:**
+
+1. `va_copy` × 2 (for original vprintf and callback formatting)
+2. `vsnprintf` to format message (256 byte buffer)
+3. String parsing (tag, level extraction)
+4. Mutex take/give for subscriber list
+5. cJSON object creation and serialization
+6. WebSocket send for each subscriber (async via httpd queue)
+
+**Mitigation:**
+
+- Small buffer size (256 bytes) reduces formatting time
+- Non-blocking mutex with 5ms timeout prevents deadlocks
+- WebSocket sending is asynchronous (httpd work queue)
+- Message truncation at 500 characters limits JSON size
+
+### Thread Safety
+
+**Critical Sections:**
+
+1. `log_subscribers_mutex_` protects `log_subscribers_` set
+2. Callback registration uses static array with implicit protection (init happens once at startup)
+
+**Lock Ordering:**
+
+- Always acquire `log_subscribers_mutex_` before any WebSocket operations
+- Timeout-based acquisition prevents deadlocks (5ms, best effort to minimally block the log context)
+
+**Reentrancy:**
+
+- `log_router_vprintf()` can be called from any task/context
+- Stack buffer is thread-safe, since `vprintf` might not be serialized for every low-level log message or when logging
+  from multiple cores.
+
+## Constraints and Limitations
+
+### Hard Limits
+
+| Parameter           | Value          | Rationale                                             |
+|---------------------|----------------|-------------------------------------------------------|
+| `MAX_LOG_CALLBACKS` | 1              | Only WebSocket API currently uses it                  |
+| `MAX_LOG_LEN`       | 256 bytes      | Fits most log messages, reduces stack usage           |
+| Message truncation  | 500 characters | Safety feature to prevent excessive WebSocket payload |
+| Mutex timeout       | 5ms            | Prevents blocking in logging path                     |
+
+### Known Limitations
+
+1. **Synchronous Callbacks:** Callbacks execute in the logging context. If a callback blocks or is slow, it delays all
+   subsequent log messages across the entire system.
+
+2. **No Log Level Filtering in Router:** All log messages are forwarded to callbacks regardless of level. Filtering must
+   be implemented in each callback if needed.
+
+3. **No Message Queuing:** If WebSocket send queue is full, log messages are dropped. No retry or buffering mechanism
+   exists.
+
+4. **Tag Parsing is Fragile:** Relies on consistent ESP-IDF log format. If ESP-IDF changes format, parsing may fail
+   silently (log field will contain full message as fallback).
+
+5. **Maximum 1 Callback:** `MAX_LOG_CALLBACKS` is set to 1. Adding syslog or other outputs requires increasing this
+   limit. This is a simple change of the `MAX_LOG_CALLBACKS` define.
+
+## Future Enhancements
+
+### Potential Features
+
+| Feature             | Priority | Description                                 |
+|---------------------|----------|---------------------------------------------|
+| Syslog output       | Medium   | Add UDP syslog callback for network logging |
+| Log level filtering | Low      | Per-callback level filter to reduce traffic |
+| Tag filtering       | Low      | Subscribe to specific tags only             |
+
+### Potential Improvements
+
+1. **Asynchronous Queue:** Add FreeRTOS queue or a ring-buffer between log router and callbacks. Callbacks would queue
+   messages and a
+   dedicated task would process them.
+
+2. **Log Buffering:** Store last N log messages in RAM for retrieval on client connect (history on subscription).
+
+## References
+
+### ESP-IDF Documentation
+
+- [Logging System](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/system/log.html)
+- `esp_log_set_vprintf()` - Override log output function
+- `esp_log_level_set()` - Set log level per tag
+
+### Related Components
+
+- `components/webserver/` - WebSocket server implementation
+- `main/ucd_api.cpp` - DockApi with log streaming integration
+- `main/ucd_api.h` - DockApi class declaration

--- a/doc/websocket-api.md
+++ b/doc/websocket-api.md
@@ -166,7 +166,7 @@ For `mode: RS232`, the UART settings can be configured with additional fields:
 - `parity`: `"none"` | `"even"` | `"odd"`
 - `stop_bits`: `"1"` | `"1.5"` | `"2"`  ❗️ this must be a string!
 
-### Trigger
+### Trigger
 
 Enable trigger (output high):
 ```json
@@ -201,3 +201,25 @@ Trigger impulse:
 
 - `duration`: time in milliseconds to set output trigger high
 
+### Log Message Events
+
+Enable log message forwarding as WebSocket event messages:
+```json
+{
+  "type": "dock",
+  "command": "enable_log_events",
+  "enable": true
+}
+```
+
+Example log event message:
+```json
+{
+    "type": "event",
+    "msg": "log",
+    "level": "I",
+    "tag": "websrv",
+    "ts": 89981,
+    "log": "Set connection 38 authenticated: 1"
+}
+```

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -22,6 +22,7 @@ idf_component_register(
     display
     external_port
     infrared
+    log_router
     network
     preferences
     webserver

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -19,6 +19,7 @@
 #include "WebServer.h"
 #include "config.h"
 #include "led_pattern.h"
+#include "log_router.h"
 #include "network.h"
 #include "sdkconfig.h"
 #include "service_ir.h"
@@ -207,10 +208,17 @@ DockApi::DockApi(Config *config, WebServer *web, port_map_t ports)
       ports_(ports),
       sockfdSendIR_(-1),
       unauthenticated_fds_mutex_(xSemaphoreCreateMutex()),
-      auth_timer_(nullptr) {
+      auth_timer_(nullptr),
+      log_subscribers_mutex_(xSemaphoreCreateMutex()),
+      log_callback_id_(-1) {
     assert(config_);
     assert(web_);
     assert(unauthenticated_fds_mutex_);
+    assert(log_subscribers_mutex_);
+
+    // Initialize log router and register callback
+    log_router_init();
+    log_router_register_callback(logCallback, this, &log_callback_id_);
 
     web_->onWsEvent([this](httpd_req_t *req, int sockfd, WsTypeEnum type, uint8_t *payload, size_t length,
                            bool authenticated) -> esp_err_t {
@@ -264,6 +272,12 @@ DockApi::DockApi(Config *config, WebServer *web, port_map_t ports)
                     xSemaphoreGive(unauthenticated_fds_mutex_);
                 }
 
+                // Remove from log subscribers
+                if (xSemaphoreTake(log_subscribers_mutex_, pdMS_TO_TICKS(1000)) == pdTRUE) {
+                    log_subscribers_.erase(sockfd);
+                    xSemaphoreGive(log_subscribers_mutex_);
+                }
+
                 return ESP_OK;
             }
             case WS_TEXT:
@@ -283,6 +297,14 @@ DockApi::~DockApi() {
         xTimerStop(auth_timer_, pdMS_TO_TICKS(1000));
     }
     vSemaphoreDelete(unauthenticated_fds_mutex_);
+
+    // Unregister log callback
+    if (log_callback_id_ >= 0) {
+        log_router_unregister_callback(log_callback_id_);
+        log_callback_id_ = -1;
+    }
+
+    vSemaphoreDelete(log_subscribers_mutex_);
 }
 
 esp_err_t DockApi::init() {
@@ -652,6 +674,9 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         code = processGetPortTrigger(root, responseDoc);
     } else if (command == "set_port_trigger") {
         code = processSetPortTrigger(root);
+    } else if (command == "enable_log_events") {
+        handleEnableLogEvents(sockfd, root, responseDoc);
+        code = ESP_OK;
     } else if (command == "reboot") {
         ESP_LOGW(TAG, "Rebooting");
         std::string message;
@@ -734,6 +759,175 @@ send_response:
     cJSON_Delete(responseDoc);
     cJSON_Delete(root);
     return ret;
+}
+
+void DockApi::handleEnableLogEvents(int sockfd, const cJSON *root, cJSON *responseDoc) {
+    bool ok = false;
+    bool enable = cjson_get_bool(root, "enable", &ok);
+
+    if (!ok) {
+        cJSON_AddNumberToObject(responseDoc, msgCode, 400);
+        cJSON_AddStringToObject(responseDoc, msgError, "Invalid or missing 'enable' field");
+        return;
+    }
+
+    if (xSemaphoreTake(log_subscribers_mutex_, pdMS_TO_TICKS(1000)) == pdTRUE) {
+        if (enable) {
+            log_subscribers_.insert(sockfd);
+            ESP_LOGI(TAG, "Client %d subscribed to log streaming (total: %d)", sockfd, log_subscribers_.size());
+        } else {
+            log_subscribers_.erase(sockfd);
+            ESP_LOGD(TAG, "Client %d unsubscribed from log streaming (total: %d)", sockfd, log_subscribers_.size());
+        }
+        xSemaphoreGive(log_subscribers_mutex_);
+    } else {
+        ESP_LOGE(TAG, "Failed to acquire log_subscribers_mutex");
+        cJSON_AddNumberToObject(responseDoc, msgCode, 500);
+        cJSON_AddStringToObject(responseDoc, msgError, "Internal error");
+        return;
+    }
+
+    cJSON_AddStringToObject(responseDoc, msgCommand, "enable_log_events");
+    cJSON_AddBoolToObject(responseDoc, "enable", enable);
+    cJSON_AddNumberToObject(responseDoc, msgCode, 200);
+}
+
+void DockApi::sendLogToSubscribers(const char *tag, esp_log_level_t level, const char *message, size_t len) {
+    // best effort, we are in the logging context and should not block
+    if (xSemaphoreTake(log_subscribers_mutex_, pdMS_TO_TICKS(5)) != pdTRUE) {
+        return;
+    }
+
+    if (log_subscribers_.empty()) {
+        xSemaphoreGive(log_subscribers_mutex_);
+        return;
+    }
+
+    // Build JSON log message using cJSON
+    cJSON *event = cJSON_CreateObject();
+    if (!event) {
+        xSemaphoreGive(log_subscribers_mutex_);
+        return;
+    }
+
+    cJSON_AddStringToObject(event, "type", "event");
+    cJSON_AddStringToObject(event, "msg", "log");
+
+    const char *level_str = "I";
+    switch (level) {
+        case ESP_LOG_ERROR:
+            level_str = "E";
+            break;
+        case ESP_LOG_WARN:
+            level_str = "W";
+            break;
+        case ESP_LOG_INFO:
+            level_str = "I";
+            break;
+        case ESP_LOG_DEBUG:
+            level_str = "D";
+            break;
+        case ESP_LOG_VERBOSE:
+            level_str = "V";
+            break;
+        default:
+            break;
+    }
+    cJSON_AddStringToObject(event, "level", level_str);
+    cJSON_AddStringToObject(event, "tag", tag);
+
+    // Parse message to extract timestamp and clean text
+    // Format: "<LEVEL> (<TS>) <TAG>: <TEXT>"
+    uint32_t    timestamp = 0;
+    const char *text_start = nullptr;
+
+    // Find timestamp in brackets
+    const char *ts_start = strchr(message, '(');
+    const char *ts_end = strchr(message, ')');
+    if (ts_start && ts_end && ts_end > ts_start) {
+        timestamp = strtoul(ts_start + 1, nullptr, 10);
+        cJSON_AddNumberToObject(event, "ts", timestamp);
+
+        // Find text after "tag: "
+        text_start = strchr(ts_end, ':');
+        if (text_start) {
+            text_start++;                             // skip ':'
+            while (*text_start == ' ') text_start++;  // skip leading spaces
+        }
+    }
+
+    // If we couldn't parse the text, use the original message
+    if (!text_start) {
+        text_start = message;
+    }
+
+    // Trim leading whitespace
+    while (*text_start == ' ' || *text_start == '\t' || *text_start == '\r' || *text_start == '\n') {
+        text_start++;
+    }
+
+    // Calculate length and trim trailing whitespace
+    size_t msg_len = strlen(text_start);
+    while (msg_len > 0) {
+        char c = text_start[msg_len - 1];
+        if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+            msg_len--;
+        } else {
+            break;
+        }
+    }
+
+    // Truncate message if too long (leave room for JSON overhead)
+    if (msg_len > 500) {
+        msg_len = 500;
+    }
+
+    // Create a null-terminated copy
+    // Note: No manual JSON escaping needed - cJSON handles this automatically
+    char *msg_copy = (char *)malloc(msg_len + 1);
+    if (!msg_copy) {
+        cJSON_Delete(event);
+        xSemaphoreGive(log_subscribers_mutex_);
+        return;
+    }
+    strncpy(msg_copy, text_start, msg_len);
+    msg_copy[msg_len] = '\0';
+
+    cJSON_AddStringToObject(event, "log", msg_copy);
+    free(msg_copy);
+
+    char *json_str = cJSON_PrintUnformatted(event);
+    cJSON_Delete(event);
+
+    if (!json_str) {
+        xSemaphoreGive(log_subscribers_mutex_);
+        return;
+    }
+
+    // Send to all subscribers
+    for (int fd : log_subscribers_) {
+        // Important: needs to be const char* to avoid freeing the buffer in sendWsTxt!
+        web_->sendWsTxt(fd, (const char *)json_str);
+    }
+
+    cJSON_free(json_str);
+    xSemaphoreGive(log_subscribers_mutex_);
+}
+
+esp_err_t DockApi::logCallback(const char *tag, esp_log_level_t level, const char *message, size_t len, void *ctx) {
+    // Attention: This callback is called from the logging system, which may have very strict timing requirements.
+    // It should not perform any heavy processing or blocking operations. The message should be forwarded to subscribers
+    // as quickly as possible, and any complex processing (like JSON formatting) should ideally be deferred to the
+    // decoupled subscriber side if possible.
+    // For the moment we keep it simple and do the JSON formatting here, but if performance becomes an issue,
+    // we should consider a more asynchronous approach where we just forward the raw log message and metadata to a
+    // queue, and have a separate task processing the queue and sending events to subscribers. Note: sending the WS
+    // messages is already asynchronous in httpd with a work queue.
+    DockApi *that = static_cast<DockApi *>(ctx);
+    if (that) {
+        that->sendLogToSubscribers(tag, level, message, len);
+    }
+    return ESP_OK;
 }
 
 uint16_t DockApi::processGetPortModes(cJSON *responseDoc) {

--- a/main/ucd_api.h
+++ b/main/ucd_api.h
@@ -7,9 +7,11 @@
 #include <stdlib.h>
 
 #include <map>
+#include <set>
 #include <string>
 
 #include "esp_http_server.h"
+#include "esp_log_level.h"
 #include "freertos/task.h"
 #include "freertos/timers.h"
 
@@ -62,6 +64,11 @@ class DockApi {
     static void authTimeoutCallback(TimerHandle_t timer_id);
     void        checkAuthTimeouts();
 
+    // Log streaming support
+    void             handleEnableLogEvents(int sockfd, const cJSON* root, cJSON* responseDoc);
+    void             sendLogToSubscribers(const char* tag, esp_log_level_t level, const char* message, size_t len);
+    static esp_err_t logCallback(const char* tag, esp_log_level_t level, const char* message, size_t len, void* ctx);
+
     Config*    config_;
     WebServer* web_;
     port_map_t ports_;
@@ -70,4 +77,9 @@ class DockApi {
     std::map<int, uint64_t> unauthenticated_fds_;
     SemaphoreHandle_t       unauthenticated_fds_mutex_;
     TimerHandle_t           auth_timer_;
+
+    // Per-client log streaming subscriptions
+    std::set<int>     log_subscribers_;
+    SemaphoreHandle_t log_subscribers_mutex_;
+    int               log_callback_id_;
 };


### PR DESCRIPTION
This PR implements a lightweight log routing infrastructure that intercepts ESP-IDF log messages and forwards them to multiple output destinations while preserving console/UART output. Primary use case is for developers to monitor real-time log messages with a WebSocket client or with the upcoming web management UI.

It is not optimized for multiple subscribers or rapid log messages! JSON WS message formatting is done in the logging context and can slow down the system.

## Key Features

- **Almost zero overhead when inactive**: Fast-path optimization skips all callback processing when no subscribers are active.
- **Console output always preserved**: Original UART/console logging continues uninterrupted.
- **Subscription-based**: WebSocket clients explicitly subscribe/unsubscribe to log streaming via API. Disabled by default.

## WebSocket API

**Subscribe to logs:**
```json
{ "type": "dock", "command": "enable_log_events", "enable": true }
```

**Log event format:**
```json
{ "type": "event", "msg": "log", "level": "I", "tag": "CHARGE", "ts": 273131, "log": "0 mV" }
```

## Components

| Component | Description |
|-----------|-------------|
| `components/log_router/` | Core log routing library (C) |
| `main/ucd_api.cpp` | WebSocket integration in DockApi class |

## Manual Testing

- Console output verified working with and without subscribers
- WebSocket subscription/unsubscription tested
- Multiple clients receive same log events
- Client disconnect properly cleans up subscriptions

## Documentation

Technical documentation with architecture details, design decisions, limitations, and troubleshooting: `doc/log-router.md`

---

LLM disclaimer: assisted with Claude, manually verified and refined.
