### PR TITLE
feat: add PoE voltage mode configuration for rev6

### DIFF
--- a/components/preferences/board.c
+++ b/components/preferences/board.c
@@ -86,6 +86,14 @@ gpio_num_t board_get_ir_send_pin_int_top(void) {
     return s_ir_send_pin_int_top;
 }
 
+gpio_num_t board_get_poe_switch_pin(void) {
+    if (s_revision == 6) {
+        return GPIO_NUM_7;
+    } else {
+        return GPIO_NUM_NC;
+    }
+}
+
 gpio_num_t board_get_charging_current_pin(void) {
     return s_charging_current_pin;
 }

--- a/components/preferences/board.h
+++ b/components/preferences/board.h
@@ -137,6 +137,9 @@ gpio_num_t board_get_spi_cs(void);
 // @return pin or GPIO_NUM_NC if not used
 gpio_num_t board_get_ir_send_pin_int_top(void);
 
+/// GPIO pin of the PoE switch (if revision has one, otherwise GPIO_NUM_NC)
+gpio_num_t board_get_poe_switch_pin(void);
+
 // GPIO pin of the charger measurement
 gpio_num_t board_get_charging_current_pin(void);
 

--- a/components/preferences/board_r6.h
+++ b/components/preferences/board_r6.h
@@ -9,6 +9,3 @@
 
 #define UCD_HW_MODEL_NAME "UCD3"
 #define UCD_HW_REVISION_NAME "6"
-
-// OUTPUT, PoE voltage switch (rev6+). Not used yet
-#define POE_SWITCH GPIO_NUM_7

--- a/components/preferences/config.cpp
+++ b/components/preferences/config.cpp
@@ -28,7 +28,7 @@ Config::Config() {
     esp_read_mac(baseMac, ESP_MAC_WIFI_STA);
     snprintf(dockHostName, sizeof(dockHostName), "UCD3-%02X%02X%02X", baseMac[3], baseMac[4], baseMac[5]);
 
-    m_hostname = dockHostName;
+    m_hostname = dockHostName;  // TODO add .local
 
     // if no friendly name is set, use mac address
     if (getFriendlyName().empty()) {
@@ -202,6 +202,10 @@ const char* Config::getModel() const {
 const char* Config::getRevision() const {
     auto efuseRev = Efuse::instance().getHwRevision();
     return strlen(efuseRev) ? efuseRev : UCD_HW_REVISION_NAME;
+}
+
+bool Config::hasPoeFeature() const {
+    return Efuse::instance().hasPoeFeature();
 }
 
 bool Config::hasChargingFeature() const {
@@ -455,6 +459,17 @@ bool Config::setSerialTimeout(uint8_t port, uint16_t timeout_ms) {
     char keyname[16];
     snprintf(keyname, sizeof(keyname), "serial%u_to", port);
     return setUShortSetting(m_prefGeneral, keyname, timeout_ms);
+}
+
+uint8_t Config::getPoeVoltageMode() {
+    return getUCharSetting(m_prefGeneral, "poe_voltage", 0);
+}
+
+bool Config::setPoeVoltageMode(uint8_t mode) {
+    if (mode > 1) {
+        mode = 1;
+    }
+    return setUCharSetting(m_prefGeneral, "poe_voltage", mode);
 }
 
 // reset config to defaults

--- a/components/preferences/config.h
+++ b/components/preferences/config.h
@@ -113,6 +113,8 @@ class Config {
     const char* getModel() const;
     // get device hardware revision
     const char* getRevision() const;
+    // check if dock supports PoE
+    bool hasPoeFeature() const;
     // check if it is a charging dock
     bool hasChargingFeature() const;
 
@@ -232,6 +234,15 @@ class Config {
     /// @param port port number, 1-based.
     /// @param timeout_ms Timeout in milliseconds. 0 = no timeout.
     bool setSerialTimeout(uint8_t port, uint16_t timeout_ms);
+
+    /// @brief Get the PoE voltage mode (if supported by hardware).
+    /// @return Mode 0 is normal operation, mode 1 enables the higher PoE voltage on compatible hardware revisions.
+    uint8_t getPoeVoltageMode();
+
+    /// @brief Set the PoE voltage mode (if supported by hardware).
+    /// @param mode Mode 0 is normal operation, mode 1 enables the higher PoE voltage on compatible hardware revisions.
+    /// @return true if configuration could be saved, false otherwise.
+    bool setPoeVoltageMode(uint8_t mode);
 
     // reset config to defaults
     void reset();

--- a/components/preferences/efuse.cpp
+++ b/components/preferences/efuse.cpp
@@ -73,6 +73,10 @@ const char* Efuse::getHwRevision() const {
     return device_desc.revision;
 }
 
+bool Efuse::hasPoeFeature() const {
+    return device_desc.features.poe;
+}
+
 bool Efuse::hasChargingFeature() const {
     return device_desc.features.charging;
 }

--- a/components/preferences/efuse.h
+++ b/components/preferences/efuse.h
@@ -12,6 +12,7 @@ class Efuse {
     const char *getModel() const;
     const char *getHwRevision() const;
 
+    bool hasPoeFeature() const;
     bool hasChargingFeature() const;
 
     static Efuse &instance();

--- a/doc/websocket-api.md
+++ b/doc/websocket-api.md
@@ -224,6 +224,23 @@ Example log event message:
 }
 ```
 
+## System Settings
+
+Set PoE voltage mode 0 or 1 (only for rev6):
+
+```json
+{
+  "type": "dock",
+  "id": 123,
+  "command": "set_poe",
+  "mode": 0
+}
+```
+
+- The PoE mode is not applied immediately, but only on boot.
+- Changing the mode will automatically reboot the device.
+- The PoE mode is returned in the `get_sysinfo` response: `"poe_mode": 1`
+
 ## RS232 Communication
 
 Send data:

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -221,6 +221,26 @@ void init_gpios(void) {
     // disable 5V & GND
     gpio_set_level(SWITCH_EXT_2, board_is_switch_ext_inverted() ? 1 : 0);
     gpio_set_level(SWITCH_GND_2, 0);
+
+    // Rev 6 PoE voltage
+    gpio_num_t poe_switch_pin = board_get_poe_switch_pin();
+    if (poe_switch_pin != GPIO_NUM_NC) {
+        gpio_init(poe_switch_pin, GPIO_MODE_OUTPUT);
+        gpio_set_level(poe_switch_pin, 0);
+    }
+}
+
+/// @brief Set the PoE voltage mode. Only applicable for hardware revisions supporting PoE voltage switching (e.g.
+/// rev6).
+/// @param mode mode 0 is normal operation, mode 1 enables the higher PoE voltage on compatible hardware revisions
+static void init_poe_voltage_mode(uint8_t mode) {
+    gpio_num_t poe_switch_pin = board_get_poe_switch_pin();
+    if (poe_switch_pin != GPIO_NUM_NC) {
+        gpio_set_level(poe_switch_pin, mode == 0 ? 0 : 1);
+        ESP_LOGI(TAG, "Set PoE voltage mode to %d", mode);
+    } else {
+        ESP_LOGD(TAG, "PoE voltage mode cannot be set: not supported");
+    }
 }
 
 /// @brief Create and configure output ports.
@@ -340,6 +360,12 @@ extern "C" void app_main(void) {
         esp_event_handler_register(UC_DOCK_EVENTS, UC_ACTION_RESET, factoryResetHandler, NULL));
 
     Config &cfg = Config::instance();
+
+    // set PoE voltage mode based on stored configuration
+    if (cfg.hasPoeFeature()) {
+        uint8_t poe_mode = cfg.getPoeVoltageMode();
+        init_poe_voltage_mode(poe_mode);
+    }
 
     static Display *display = Display::instance(&cfg);
     if (display->init() == ESP_OK) {

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -115,6 +115,10 @@ void fill_sysinfo_to_json(cJSON *root) {
     char buf[1 + 8 * sizeof(uint32_t)];
     utoa(heap_caps_get_free_size(MALLOC_CAP_INTERNAL), buf, 10);
     cJSON_AddStringToObject(root, "free_heap", buf);
+
+    if (board_get_poe_switch_pin() != GPIO_NUM_NC) {
+        cJSON_AddNumberToObject(root, "poe_mode", cfg.getPoeVoltageMode());
+    }
 }
 
 char *get_sysinfo_json(void) {
@@ -532,7 +536,6 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
             if (config_->setWifi(ssid, pwd)) {
                 ESP_LOGD(TAG, "Saving SSID: %s", ssid);
 
-                std::string message;
                 cJSON_AddBoolToObject(responseDoc, "reboot", true);
                 ok = true;
 
@@ -735,12 +738,10 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         code = handleEnableLogEvents(sockfd, root, responseDoc);
     } else if (command == "reboot") {
         ESP_LOGW(TAG, "Rebooting");
-        std::string message;
         cJSON_AddBoolToObject(responseDoc, "reboot", true);
         schedule_restart(web, 2000);
     } else if (command == "reset") {
         ESP_LOGW(TAG, "Reset");
-        std::string message;
         cJSON_AddBoolToObject(responseDoc, "reboot", true);
         schedule_restart(web, 2000, true);
     } else if (command == "set_ir_config") {
@@ -824,6 +825,24 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
             code = 200;
         } else {
             code = 500;
+        }
+    } else if (command == "set_poe") {
+        if (!config_->hasPoeFeature() || board_get_poe_switch_pin() == GPIO_NUM_NC) {
+            code = 400;
+        } else {
+            bool ok = false;
+            int  mode = cjson_get_int(root, "mode", &ok);
+            if (ok && mode >= 0 && mode <= 1) {
+                int old_mode = config_->getPoeVoltageMode();
+                config_->setPoeVoltageMode(mode);
+                if (old_mode != mode) {
+                    ESP_LOGW(TAG, "Rebooting");
+                    cJSON_AddBoolToObject(responseDoc, "reboot", true);
+                    schedule_restart(web, 2000);
+                }
+            } else {
+                code = 400;
+            }
         }
     } else {
         code = 400;


### PR DESCRIPTION
Allow setting the voltage mode on revision 6: default or increased voltage.

- Setting is only applied at startup.
- New WS message `set_poe` to change mode.
- Current setting is returned with `get_sysinfo`.
- Changing the setting will automatically reboot the dock.