### PR TITLE
Static network configuration

### DIFF
--- a/components/display/src/EventParameter.cpp
+++ b/components/display/src/EventParameter.cpp
@@ -71,7 +71,7 @@ EventParameter::EventParameter(ui_event_queue_message* event) : icon_(UI_ICON_NO
                     snprintf(buf, sizeof(buf), IPV6STR, IPV62STR(event_net_state->ip.u_addr.ip6));
                 }
                 icon_ = event_net_state->connection == ETHERNET ? UI_ICON_ETHERNET : UI_ICON_WIFI;
-                title_ = "DHCP";
+                title_ = event_net_state->dhcp ? "DHCP" : "STATIC";
                 message_ = buf;
                 value_ = event_net_state->connection;
             }

--- a/components/external_port/external_port.cpp
+++ b/components/external_port/external_port.cpp
@@ -512,8 +512,6 @@ void ExternalPort::applyVector(int g, int e, int t, bool is_mono) {
 }
 
 ExtPortMode ExternalPort::detectPortType() {
-    esp_err_t ret = ESP_OK;
-
     const size_t test_cases = sizeof(VECTOR) / sizeof(vector_t);
     int          voltages[test_cases];
     int          rx_vals[test_cases];

--- a/components/infrared/globalcache_server.cpp
+++ b/components/infrared/globalcache_server.cpp
@@ -191,12 +191,12 @@ void GlobalCacheServer::tcp_server_task(void *param) {
         // Convert ip address to string
 #ifdef USE_IPV4
         if (source_addr.ss_family == PF_INET) {
-            inet_ntoa_r(((struct sockaddr_in *)&source_addr)->sin_addr, addr_str, sizeof(addr_str) - 1);
+            inet_ntoa_r(((struct sockaddr_in *)&source_addr)->sin_addr, addr_str, sizeof(addr_str));
         }
 #endif
 #ifdef USE_IPV6
         if (source_addr.ss_family == PF_INET6) {
-            inet6_ntoa_r(((struct sockaddr_in6 *)&source_addr)->sin6_addr, addr_str, sizeof(addr_str) - 1);
+            inet6_ntoa_r(((struct sockaddr_in6 *)&source_addr)->sin6_addr, addr_str, sizeof(addr_str));
         }
 #endif
         ESP_LOGI(TAG_GC, "Socket accepted client: %s", addr_str);

--- a/components/network/include/network.h
+++ b/components/network/include/network.h
@@ -108,6 +108,9 @@ esp_err_t set_eth_led_brightness(int value);
 /// @return ESP_OK if successful
 esp_err_t set_static_ip(esp_netif_t* netif, esp_netif_ip_info_t ip, uint32_t dns1, uint32_t dns2);
 
+/// @brief Apply configured DNS servers to currently active network interface.
+void apply_custom_dns();
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/network/include/network.h
+++ b/components/network/include/network.h
@@ -47,7 +47,7 @@ typedef enum update_reason_code_t {
     UPDATE_WIFI_PROVISIONING
 } update_reason_code_t;
 
-esp_err_t network_start(void);
+esp_err_t network_start(bool enable_sntp);
 
 // --- Public state machine events --------------------------------------------
 

--- a/components/network/src/NetworkSmBase.cpp
+++ b/components/network/src/NetworkSmBase.cpp
@@ -110,12 +110,11 @@ void NetworkBase::initNetwork() {
     ESP_ERROR_CHECK(esp_netif_init());
     ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, ESP_EVENT_ANY_ID, &network_ip_event_handler, NULL));
 
-    if (Config::instance().isNtpEnabled()) {
-        auto ret = init_sntp();
-        // don't abort, SNTP is not required for the dock to function
-        if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to initialize SNTP (%d): %s", ret, esp_err_to_name(ret));
-        }
+    // always initialize; SNTP start is gated by sntp_enabled in network.cpp
+    auto ret = init_sntp();
+    // don't abort, SNTP is not required for the dock to function
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to initialize SNTP (%d): %s", ret, esp_err_to_name(ret));
     }
 
     init_improv();

--- a/components/network/src/NetworkSmBase.cpp
+++ b/components/network/src/NetworkSmBase.cpp
@@ -367,6 +367,9 @@ void NetworkBase::statusUpdate(update_reason_code_t update_reason_code) {
     // send custom system event (used by display state-machine)
     esp_netif_ip_info_t      ip_info;
     uc_event_network_state_t net_state;
+    Config                  &config = Config::instance();
+    network_cfg_t            netcfg = config.getNetwork();
+
     memset(&net_state, 0, sizeof(net_state));
     net_state.connection = WIFI;
     net_state.eth_link = is_eth_link_up();
@@ -390,7 +393,6 @@ void NetworkBase::statusUpdate(update_reason_code_t update_reason_code) {
         case UPDATE_LOST_CONNECTION: {
             event_id = UC_EVENT_DISCONNECTED;
             // use configured SSID
-            Config     &config = Config::instance();
             std::string ssid = config.getWifiSsid();
             strncpy(reinterpret_cast<char *>(net_state.ssid), ssid.c_str(), sizeof(net_state.ssid));
             break;
@@ -402,7 +404,6 @@ void NetworkBase::statusUpdate(update_reason_code_t update_reason_code) {
             event_id = UC_EVENT_DISCONNECTED;
             // Using the confiugred SSID might not be the expected information if a user wanted to connect to a new AP!
             // Since the UI screens are not yet finalized, this is good enough for now :-)
-            Config     &config = Config::instance();
             std::string ssid = config.getWifiSsid();
             strncpy(reinterpret_cast<char *>(net_state.ssid), ssid.c_str(), sizeof(net_state.ssid));
             break;
@@ -443,6 +444,15 @@ void NetworkBase::statusUpdate(update_reason_code_t update_reason_code) {
     }
 
     assert(event_id);
+
+    switch (net_state.connection) {
+        case WIFI:
+            net_state.dhcp = netcfg.wifi.dhcp;
+            break;
+        case ETHERNET:
+            net_state.dhcp = netcfg.eth.dhcp;
+            break;
+    }
 
     ESP_ERROR_CHECK_WITHOUT_ABORT(
         esp_event_post(UC_DOCK_EVENTS, event_id, &net_state, sizeof(net_state), pdMS_TO_TICKS(1000)));
@@ -513,6 +523,7 @@ void NetworkBase::setImprovProvisioning() {
     net_state.connection = WIFI;
     net_state.eth_link = is_eth_link_up();
     net_state.ip.type = ESP_IPADDR_TYPE_ANY;
+    net_state.dhcp = true;  // Improv provisioning always uses DHCP
 
     if (event_parameters_.ssid) {
         strncpy(reinterpret_cast<char *>(net_state.ssid), event_parameters_.ssid, sizeof(net_state.ssid));

--- a/components/network/src/NetworkSmBase.cpp
+++ b/components/network/src/NetworkSmBase.cpp
@@ -141,6 +141,9 @@ void NetworkBase::initEthernet() {
     ESP_GOTO_ON_ERROR(esp_netif_attach(eth_netif_, eth_netif_glues), err, TAG,
                       "Failed to attach eth driver to tcp/ip stack");
 
+    ESP_LOGI(TAG, "Applying IPv4 config for ETH");
+    ESP_GOTO_ON_ERROR(apply_eth_ipv4_config(eth_netif_), err, TAG, "Failed to apply ETH IPv4 config");
+
     // Register user defined event handers
     ESP_GOTO_ON_ERROR(esp_event_handler_register(ETH_EVENT, ESP_EVENT_ANY_ID, &eth_event_handler, NULL), err, TAG,
                       "Failed to register eth event handler");
@@ -215,6 +218,7 @@ void NetworkBase::setTimer(uint32_t timeout_ms, const char *tag) {
         state_timer_ = xTimerCreate("network", pdMS_TO_TICKS(timeout_ms), pdFALSE, timer_tag_, network_timer_cb);
     } else {
         ESP_LOGI(TAG, "Changing '%s' timer-period to %lums.", timer_tag_, timeout_ms);
+        vTimerSetTimerID(state_timer_, timer_tag_);
         xTimerChangePeriod(state_timer_, pdMS_TO_TICKS(timeout_ms), portMAX_DELAY);
     }
     xTimerStart(state_timer_, portMAX_DELAY);
@@ -447,7 +451,16 @@ void NetworkBase::statusUpdate(update_reason_code_t update_reason_code) {
 
 void NetworkBase::startWifiDhcpClient() {
     ESP_LOGI(TAG, "startWifiDhcpClient");
-    network_start_stop_dhcp_client(wifi_netif_, true);
+
+    if (!wifi_netif_) {
+        ESP_LOGW(TAG, "No WiFi netif, cannot configure IPv4");
+        return;
+    }
+
+    esp_err_t ret = apply_wifi_ipv4_config(wifi_netif_);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to apply WiFi IPv4 config: %s", esp_err_to_name(ret));
+    }
 }
 
 void host_task(void *param) {

--- a/components/network/src/network.cpp
+++ b/components/network/src/network.cpp
@@ -17,6 +17,8 @@
 #include "freertos/event_groups.h"
 #include "freertos/queue.h"
 #include "lwip/inet.h"
+#include "lwip/ip4_addr.h"
+#include "lwip/ip6_addr.h"
 
 #include "NetworkSm.h"
 #include "config.h"
@@ -494,16 +496,73 @@ esp_err_t network_get_ip_info_for_netif(esp_netif_t *netif, esp_netif_ip_info_t 
     return err;
 }
 
-static esp_err_t set_dns_server(esp_netif_t *netif, ip4_addr_t ip4, esp_netif_dns_type_t type) {
-    if (ip4.addr && (ip4.addr != IPADDR_NONE)) {
-        esp_netif_dns_info_t dns = {};
-        dns.ip.u_addr.ip4.addr = ip4.addr;
-        dns.ip.type = IPADDR_TYPE_V4;
-        ESP_LOGI(TAG, "Setting DNS server: %s", ip4addr_ntoa((ip4_addr_t *)&dns.ip.u_addr.ip4));
-        return esp_netif_set_dns_info(netif, type, &dns);
+static bool parse_dns_addr(const std::string &value, esp_ip_addr_t *addr) {
+    if (value.empty() || !addr) {
+        return false;
     }
 
-    return ESP_OK;
+    memset(addr, 0, sizeof(*addr));
+
+    ip4_addr_t ip4 = {};
+    if (ip4addr_aton(value.c_str(), &ip4) != 0 && ip4.addr != IPADDR_ANY && ip4.addr != IPADDR_NONE) {
+        addr->type = IPADDR_TYPE_V4;
+        addr->u_addr.ip4.addr = ip4.addr;
+        return true;
+    }
+
+#if CONFIG_LWIP_IPV6
+    ip6_addr_t ip6 = {};
+    if (ip6addr_aton(value.c_str(), &ip6) != 0 && !ip6_addr_isany_val(ip6)) {
+        addr->type = IPADDR_TYPE_V6;
+        memcpy(&addr->u_addr.ip6, &ip6, sizeof(addr->u_addr.ip6));
+        return true;
+    }
+#endif
+
+    return false;
+}
+
+static const char *dns_addr_to_string(const esp_ip_addr_t *addr, char *buf, size_t buf_len) {
+    if (!addr || !buf || buf_len == 0) {
+        return nullptr;
+    }
+
+    switch (addr->type) {
+        case IPADDR_TYPE_V4:
+            if (addr->u_addr.ip4.addr == IPADDR_ANY || addr->u_addr.ip4.addr == IPADDR_NONE) {
+                return nullptr;
+            }
+            return ip4addr_ntoa_r((const ip4_addr_t *)&addr->u_addr.ip4, buf, buf_len);
+
+#if CONFIG_LWIP_IPV6
+        case IPADDR_TYPE_V6:
+            if (ip6_addr_isany((const ip6_addr_t *)&addr->u_addr.ip6)) {
+                return nullptr;
+            }
+            return ip6addr_ntoa_r((const ip6_addr_t *)&addr->u_addr.ip6, buf, buf_len);
+#endif
+
+        default:
+            return nullptr;
+    }
+}
+
+static esp_err_t set_dns_server(esp_netif_t *netif, const std::string &server, esp_netif_dns_type_t type) {
+    if (server.empty()) {
+        return ESP_OK;
+    }
+
+    esp_netif_dns_info_t dns = {};
+    if (!parse_dns_addr(server, &dns.ip)) {
+        ESP_LOGW(TAG, "Ignoring invalid DNS server address: %s", server.c_str());
+        return ESP_OK;
+    }
+
+    char        addr_str[48] = {};
+    const char *formatted = dns_addr_to_string(&dns.ip, addr_str, sizeof(addr_str));
+    ESP_LOGI(TAG, "Setting DNS server: %s", formatted ? formatted : server.c_str());
+
+    return esp_netif_set_dns_info(netif, type, &dns);
 }
 
 void apply_custom_dns() {
@@ -532,17 +591,17 @@ static void apply_custom_dns_if_any(esp_netif_t *netif) {
 
     Config &cfg = Config::instance();
 
-    ip4_addr_t dns1 = cfg.getDnsServer1();
-    ip4_addr_t dns2 = cfg.getDnsServer2();
+    std::string dns1 = cfg.getDnsServer1();
+    std::string dns2 = cfg.getDnsServer2();
 
-    if (dns1.addr != IPADDR_NONE) {
+    if (!dns1.empty()) {
         esp_err_t err = set_dns_server(netif, dns1, ESP_NETIF_DNS_MAIN);
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "Failed to set main DNS server: %s", esp_err_to_name(err));
         }
     }
 
-    if (dns2.addr != IPADDR_NONE) {
+    if (!dns2.empty()) {
         esp_err_t err = set_dns_server(netif, dns2, ESP_NETIF_DNS_BACKUP);
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "Failed to set backup DNS server: %s", esp_err_to_name(err));

--- a/components/network/src/network.cpp
+++ b/components/network/src/network.cpp
@@ -480,7 +480,7 @@ esp_err_t init_sntp() {
         ESP_LOGI(TAG, "SNTP: DHCP, pool.ntp.org fallback");
     }
 
-    // always required: otherwise lwIP does NOT make copies of our custom servers during initialization!
+    // always required: otherwise esp_netif_sntp_init does NOT make copies of our custom servers during initialization!
     sntp_config.renew_servers_after_new_IP = true;
     sntp_config.start = false;
     sntp_config.sync_cb = on_got_time;

--- a/components/network/src/network.cpp
+++ b/components/network/src/network.cpp
@@ -494,41 +494,16 @@ esp_err_t network_get_ip_info_for_netif(esp_netif_t *netif, esp_netif_ip_info_t 
     return err;
 }
 
-static esp_err_t set_dns_server(esp_netif_t *netif, uint32_t addr, esp_netif_dns_type_t type) {
-    if (addr && (addr != IPADDR_NONE)) {
+static esp_err_t set_dns_server(esp_netif_t *netif, ip4_addr_t ip4, esp_netif_dns_type_t type) {
+    if (ip4.addr && (ip4.addr != IPADDR_NONE)) {
         esp_netif_dns_info_t dns = {};
-        dns.ip.u_addr.ip4.addr = addr;
+        dns.ip.u_addr.ip4.addr = ip4.addr;
         dns.ip.type = IPADDR_TYPE_V4;
         ESP_LOGI(TAG, "Setting DNS server: %s", ip4addr_ntoa((ip4_addr_t *)&dns.ip.u_addr.ip4));
         return esp_netif_set_dns_info(netif, type, &dns);
     }
 
     return ESP_OK;
-}
-
-static uint32_t parse_dns_server(const std::string &server, const char *name) {
-    if (server.empty()) {
-        return 0;
-    }
-
-    uint32_t addr = ipaddr_addr(server.c_str());
-    if (addr == IPADDR_NONE) {
-        ESP_LOGW(TAG, "Invalid %s address: %s", name, server.c_str());
-        return 0;
-    }
-
-    return addr;
-}
-
-static void get_configured_dns_servers(uint32_t *dns1, uint32_t *dns2) {
-    Config &cfg = Config::instance();
-
-    if (dns1) {
-        *dns1 = parse_dns_server(cfg.getDnsServer1(), "DNS1");
-    }
-    if (dns2) {
-        *dns2 = parse_dns_server(cfg.getDnsServer2(), "DNS2");
-    }
 }
 
 void apply_custom_dns() {
@@ -553,18 +528,19 @@ static void apply_custom_dns_if_any(esp_netif_t *netif) {
         return;
     }
 
-    uint32_t dns1 = 0;
-    uint32_t dns2 = 0;
-    get_configured_dns_servers(&dns1, &dns2);
+    Config &cfg = Config::instance();
 
-    if (dns1) {
+    ip4_addr_t dns1 = cfg.getDnsServer1();
+    ip4_addr_t dns2 = cfg.getDnsServer2();
+
+    if (dns1.addr != IPADDR_NONE) {
         esp_err_t err = set_dns_server(netif, dns1, ESP_NETIF_DNS_MAIN);
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "Failed to set main DNS server: %s", esp_err_to_name(err));
         }
     }
 
-    if (dns2) {
+    if (dns2.addr != IPADDR_NONE) {
         esp_err_t err = set_dns_server(netif, dns2, ESP_NETIF_DNS_BACKUP);
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "Failed to set backup DNS server: %s", esp_err_to_name(err));

--- a/components/network/src/network.cpp
+++ b/components/network/src/network.cpp
@@ -380,6 +380,7 @@ void network_ip_event_handler(void *arg, esp_event_base_t event_base, int32_t ev
         case IP_EVENT_AP_STAIPASSIGNED:
             ESP_LOGI(TAG, "IP_EVENT_AP_STAIPASSIGNED");
             break;
+#if CONFIG_LWIP_IPV6
         case IP_EVENT_GOT_IP6: {
             ip_event_got_ip6_t *event = (ip_event_got_ip6_t *)event_data;
             const char         *if_key = "unknown";
@@ -395,6 +396,7 @@ void network_ip_event_handler(void *arg, esp_event_base_t event_base, int32_t ev
                      ip6addr_ntoa((ip6_addr_t *)&event->ip6_info.ip));
             break;
         }
+#endif
         default:
             break;
     }

--- a/components/network/src/network.cpp
+++ b/components/network/src/network.cpp
@@ -16,6 +16,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
 #include "freertos/queue.h"
+#include "lwip/inet.h"
 
 #include "NetworkSm.h"
 #include "config.h"
@@ -41,6 +42,23 @@ static NetworkSm networkSm;
 
 static void network_task(void *pvParameters);
 static void queue_sm_event(NetworkSm::EventId event);
+static void apply_custom_dns_if_any(esp_netif_t *netif);
+
+#if CONFIG_LWIP_IPV6
+static void create_ipv6_linklocal(esp_netif_t *netif, const char *if_name) {
+    if (!netif) {
+        ESP_LOGW(TAG, "Cannot create IPv6 link-local address for %s: netif is NULL", if_name);
+        return;
+    }
+
+    esp_err_t err = esp_netif_create_ip6_linklocal(netif);
+    if (err == ESP_OK) {
+        ESP_LOGI(TAG, "Creating IPv6 link-local address for %s", if_name);
+    } else if (err != ESP_ERR_INVALID_STATE) {
+        ESP_LOGW(TAG, "Failed to create IPv6 link-local address for %s: %s", if_name, esp_err_to_name(err));
+    }
+}
+#endif
 
 esp_err_t network_start() {
     if (network_queue) {
@@ -288,6 +306,11 @@ void eth_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id,
             esp_eth_ioctl(eth_handle, ETH_CMD_G_MAC_ADDR, mac_addr);
             ESP_LOGI(TAG, "Ethernet Link Up, HW Addr %02x:%02x:%02x:%02x:%02x:%02x", mac_addr[0], mac_addr[1],
                      mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
+
+#if CONFIG_LWIP_IPV6
+            create_ipv6_linklocal(esp_netif_get_handle_from_ifkey("ETH_DEF"), "ETH");
+#endif
+
             wifi_disconnect();
             set_eth_led_brightness(Config::instance().getEthLedBrightness());
             if (eth_event_group) {
@@ -334,7 +357,11 @@ void network_ip_event_handler(void *arg, esp_event_base_t event_base, int32_t ev
 
             event_id == IP_EVENT_ETH_GOT_IP ? trigger_eth_got_ip_event() : trigger_wifi_got_ip_event();
 
-            if (eth_event_group) {
+            if (event->esp_netif) {
+                apply_custom_dns_if_any(event->esp_netif);
+            }
+
+            if (eth_event_group && event_id == IP_EVENT_ETH_GOT_IP) {
                 xEventGroupSetBits(eth_event_group, ETH_GOT_IP_BIT);
             }
 
@@ -353,9 +380,21 @@ void network_ip_event_handler(void *arg, esp_event_base_t event_base, int32_t ev
         case IP_EVENT_AP_STAIPASSIGNED:
             ESP_LOGI(TAG, "IP_EVENT_AP_STAIPASSIGNED");
             break;
-        case IP_EVENT_GOT_IP6:
-            ESP_LOGI(TAG, "IP_EVENT_GOT_IP6");
+        case IP_EVENT_GOT_IP6: {
+            ip_event_got_ip6_t *event = (ip_event_got_ip6_t *)event_data;
+            const char         *if_key = "unknown";
+
+            if (event && event->esp_netif) {
+                const char *key = esp_netif_get_ifkey(event->esp_netif);
+                if (key) {
+                    if_key = key;
+                }
+            }
+
+            ESP_LOGI(TAG, "Got IPv6 address on interface %s: %s", if_key,
+                     ip6addr_ntoa((ip6_addr_t *)&event->ip6_info.ip));
             break;
+        }
         default:
             break;
     }
@@ -455,16 +494,67 @@ esp_err_t network_get_ip_info_for_netif(esp_netif_t *netif, esp_netif_ip_info_t 
 
 static esp_err_t set_dns_server(esp_netif_t *netif, uint32_t addr, esp_netif_dns_type_t type) {
     if (addr && (addr != IPADDR_NONE)) {
-        esp_netif_dns_info_t dns;
+        esp_netif_dns_info_t dns = {};
         dns.ip.u_addr.ip4.addr = addr;
         dns.ip.type = IPADDR_TYPE_V4;
+        ESP_LOGI(TAG, "Setting DNS server: %s", ip4addr_ntoa((ip4_addr_t *)&dns.ip.u_addr.ip4));
         return esp_netif_set_dns_info(netif, type, &dns);
     }
 
     return ESP_OK;
 }
 
-esp_err_t set_static_ip(esp_netif_t *netif, esp_netif_ip_info_t ip, uint32_t dns1, uint32_t dns2) {
+static uint32_t parse_dns_server(const std::string &server, const char *name) {
+    if (server.empty()) {
+        return 0;
+    }
+
+    uint32_t addr = ipaddr_addr(server.c_str());
+    if (addr == IPADDR_NONE) {
+        ESP_LOGW(TAG, "Invalid %s address: %s", name, server.c_str());
+        return 0;
+    }
+
+    return addr;
+}
+
+static void get_configured_dns_servers(uint32_t *dns1, uint32_t *dns2) {
+    Config &cfg = Config::instance();
+
+    if (dns1) {
+        *dns1 = parse_dns_server(cfg.getDnsServer1(), "DNS1");
+    }
+    if (dns2) {
+        *dns2 = parse_dns_server(cfg.getDnsServer2(), "DNS2");
+    }
+}
+
+static void apply_custom_dns_if_any(esp_netif_t *netif) {
+    if (!netif) {
+        ESP_LOGW(TAG, "apply_custom_dns_if_any: netif is NULL");
+        return;
+    }
+
+    uint32_t dns1 = 0;
+    uint32_t dns2 = 0;
+    get_configured_dns_servers(&dns1, &dns2);
+
+    if (dns1) {
+        esp_err_t err = set_dns_server(netif, dns1, ESP_NETIF_DNS_MAIN);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to set main DNS server: %s", esp_err_to_name(err));
+        }
+    }
+
+    if (dns2) {
+        esp_err_t err = set_dns_server(netif, dns2, ESP_NETIF_DNS_BACKUP);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to set backup DNS server: %s", esp_err_to_name(err));
+        }
+    }
+}
+
+esp_err_t set_static_ip(esp_netif_t *netif, esp_netif_ip_info_t ip) {
     esp_err_t ret = ESP_OK;
 
     ret = esp_netif_dhcpc_stop(netif);
@@ -475,8 +565,51 @@ esp_err_t set_static_ip(esp_netif_t *netif, esp_netif_ip_info_t ip, uint32_t dns
 
     ESP_RETURN_ON_ERROR(esp_netif_set_ip_info(netif, &ip), TAG, "Failed to set ip info");
 
-    ESP_RETURN_ON_ERROR(set_dns_server(netif, dns1, ESP_NETIF_DNS_MAIN), TAG, "Failed to set DNS server");
-    ESP_RETURN_ON_ERROR(set_dns_server(netif, dns2, ESP_NETIF_DNS_BACKUP), TAG, "Failed to set backup DNS server");
+    apply_custom_dns_if_any(netif);
 
     return ESP_OK;
+}
+
+esp_err_t apply_eth_ipv4_config(esp_netif_t *netif) {
+    if (!netif) {
+        ESP_LOGE(TAG, "apply_eth_ipv4_config: null netif");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    network_cfg_t    nc = Config::instance().getNetwork();
+    iface_net_cfg_t *eth = &nc.eth;
+
+    if (eth->dhcp) {
+        ESP_LOGI(TAG, "ETH using DHCP");
+        network_start_stop_dhcp_client(netif, true);
+
+        // Initial attempt; DHCP may overwrite this, so re-apply after GOT_IP too.
+        apply_custom_dns_if_any(netif);
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "ETH using static IPv4");
+    return set_static_ip(netif, eth->ip);
+}
+
+esp_err_t apply_wifi_ipv4_config(esp_netif_t *netif) {
+    if (!netif) {
+        ESP_LOGE(TAG, "apply_wifi_ipv4_config: null netif");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    network_cfg_t    nc = Config::instance().getNetwork();
+    iface_net_cfg_t *wifi = &nc.wifi;
+
+    if (wifi->dhcp) {
+        ESP_LOGI(TAG, "WiFi using DHCP");
+        network_start_stop_dhcp_client(netif, true);
+
+        // Initial attempt; DHCP may overwrite this, so re-apply after GOT_IP too.
+        apply_custom_dns_if_any(netif);
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "WiFi using static IPv4");
+    return set_static_ip(netif, wifi->ip);
 }

--- a/components/network/src/network.cpp
+++ b/components/network/src/network.cpp
@@ -531,6 +531,22 @@ static void get_configured_dns_servers(uint32_t *dns1, uint32_t *dns2) {
     }
 }
 
+void apply_custom_dns() {
+    esp_netif_t *netif = nullptr;
+
+    if (is_eth_connected()) {
+        netif = esp_netif_get_handle_from_ifkey("ETH_DEF");
+    } else if (is_wifi_up()) {
+        netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+    }
+
+    if (netif) {
+        apply_custom_dns_if_any(netif);
+    } else {
+        ESP_LOGW(TAG, "No active network interface found to apply custom DNS settings");
+    }
+}
+
 static void apply_custom_dns_if_any(esp_netif_t *netif) {
     if (!netif) {
         ESP_LOGW(TAG, "apply_custom_dns_if_any: netif is NULL");

--- a/components/network/src/network.cpp
+++ b/components/network/src/network.cpp
@@ -383,6 +383,11 @@ void network_ip_event_handler(void *arg, esp_event_base_t event_base, int32_t ev
             if (sntp_enabled && !sntp_initialized) {
                 sntp_initialized = true;
                 ESP_ERROR_CHECK_WITHOUT_ABORT(esp_netif_sntp_start());
+                // esp_netif_sntp_start() calls sntp_stop()+sntp_init() without
+                // re-applying server names. Force a renew immediately so that the
+                // strdup'd names in s_storage are pushed back into lwIP via
+                // sntp_setservername() before the first poll fires.
+                esp_netif_sntp_renew_servers(NULL, IP_EVENT, event_id, event_data);
                 ESP_LOGI(TAG, "SNTP started on first IP event (%s). Renew: %ds",
                          event_id == IP_EVENT_ETH_GOT_IP ? "ETH" : "WiFi", CONFIG_LWIP_SNTP_UPDATE_DELAY / 1000);
             }

--- a/components/network/src/network.cpp
+++ b/components/network/src/network.cpp
@@ -508,11 +508,13 @@ static esp_err_t set_dns_server(esp_netif_t *netif, ip4_addr_t ip4, esp_netif_dn
 
 void apply_custom_dns() {
     esp_netif_t *netif = nullptr;
+    esp_netif_t *eth_netif = esp_netif_get_handle_from_ifkey("ETH_DEF");
+    esp_netif_t *wifi_netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
 
-    if (is_eth_connected()) {
-        netif = esp_netif_get_handle_from_ifkey("ETH_DEF");
-    } else if (is_wifi_up()) {
-        netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+    if (is_eth_connected() && network_is_interface_connected(eth_netif)) {
+        netif = eth_netif;
+    } else if (network_is_interface_connected(wifi_netif)) {
+        netif = wifi_netif;
     }
 
     if (netif) {

--- a/components/network/src/network.cpp
+++ b/components/network/src/network.cpp
@@ -31,7 +31,8 @@
 
 static const char *const TAG = "NET";
 
-static bool enable_sntp = true;
+static bool sntp_enabled = false;      // set by network_start()
+static bool sntp_initialized = false;  // one-shot start guard
 
 EventGroupHandle_t eth_event_group = nullptr;
 static const int   ETH_LINK_UP_BIT = BIT0;
@@ -45,6 +46,17 @@ static NetworkSm networkSm;
 static void network_task(void *pvParameters);
 static void queue_sm_event(NetworkSm::EventId event);
 static void apply_custom_dns_if_any(esp_netif_t *netif);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Manually declare the private ESP-IDF function signature
+void esp_netif_sntp_renew_servers(void *handler_args, esp_event_base_t base, int32_t event_id, void *event_data);
+
+#ifdef __cplusplus
+}
+#endif
 
 #if CONFIG_LWIP_IPV6
 static void create_ipv6_linklocal(esp_netif_t *netif, const char *if_name) {
@@ -62,10 +74,11 @@ static void create_ipv6_linklocal(esp_netif_t *netif, const char *if_name) {
 }
 #endif
 
-esp_err_t network_start() {
+esp_err_t network_start(bool enable_sntp) {
     if (network_queue) {
         return ESP_ERR_INVALID_STATE;
     }
+    sntp_enabled = enable_sntp;
 
     eth_event_group = xEventGroupCreate();
     xEventGroupClearBits(eth_event_group, ETH_LINK_UP_BIT | ETH_GOT_IP_BIT);
@@ -367,15 +380,12 @@ void network_ip_event_handler(void *arg, esp_event_base_t event_base, int32_t ev
                 xEventGroupSetBits(eth_event_group, ETH_GOT_IP_BIT);
             }
 
-            // FIXME put in state machine!
-            if (enable_sntp) {
-                // TODO are further disconnect & connect network events handled internally by SNTP?
-                enable_sntp = false;
+            if (sntp_enabled && !sntp_initialized) {
+                sntp_initialized = true;
                 esp_netif_sntp_start();
+                ESP_LOGI(TAG, "SNTP started on first IP event (%s)", event_id == IP_EVENT_ETH_GOT_IP ? "ETH" : "WiFi");
             }
-
-            break;
-        }
+        } break;
         case IP_EVENT_STA_LOST_IP:
             ESP_LOGI(TAG, "IP_EVENT_STA_LOST_IP");
             break;
@@ -413,20 +423,77 @@ void on_got_time(struct timeval *tv) {
     ESP_LOGI(TAG, "SNTP update %s: %s", server ? server : "", buffer);
 }
 
-/// @brief Initialize SNTP, use DHCP provided NTP server (option 042) with pool.ntp.org as fallback.
-/// @details This requires at least 2 SNTP servers (CONFIG_LWIP_SNTP_MAX_SERVERS=2) and CONFIG_LWIP_DHCP_GET_NTP_SRV=y
-/// @see
-/// https://docs.espressif.com/projects/esp-idf/en/v5.3.1/esp32s3/api-reference/network/esp_netif.html#use-both-static-and-dynamic-servers
-/// @return ESP_OK or ESP_FAIL
+/**
+ * @brief Initialize SNTP.
+ *
+ * Server selection logic:
+ *   - No custom servers configured: DHCP option 42 at slot 0, "pool.ntp.org" at slot 1
+ *     (fallback). Requires CONFIG_LWIP_SNTP_MAX_SERVERS >= 2.
+ *   - One custom server configured: slot 0 = server1. DHCP and fallback disabled.
+ *   - Two custom servers configured: slot 0 = server1, slot 1 = server2. DHCP and
+ *     fallback disabled. Requires CONFIG_LWIP_SNTP_MAX_SERVERS >= 2.
+ *
+ * @return ESP_OK or error code
+ */
 esp_err_t init_sntp() {
-    esp_sntp_config_t sntp_config = ESP_NETIF_SNTP_DEFAULT_CONFIG("pool.ntp.org");
+    Config           &cfg = Config::instance();
+    const std::string ntp1 = cfg.getNtpServer1();
+    const std::string ntp2 = cfg.getNtpServer2();
+    const bool        use_custom = !ntp1.empty();
+
+    esp_sntp_config_t sntp_config;
+
+    if (use_custom) {
+        // --- Custom server(s): no DHCP, no fallback ---
+        // Servers are placed starting at slot 0; DHCP slot reservation not needed.
+        sntp_config = ESP_NETIF_SNTP_DEFAULT_CONFIG(ntp1.c_str());
+        sntp_config.server_from_dhcp = false;
+        sntp_config.renew_servers_after_new_IP = false;
+        sntp_config.index_of_first_server = 0;
+
+        if (!ntp2.empty()) {
+#if CONFIG_LWIP_SNTP_MAX_SERVERS >= 2
+            sntp_config.num_of_servers = 2;
+            sntp_config.servers[1] = ntp2.c_str();
+            ESP_LOGI(TAG, "SNTP: custom servers %s (slot0), %s (slot1)", ntp1.c_str(), ntp2.c_str());
+#else
+            ESP_LOGW(TAG, "Second NTP server '%s' ignored: CONFIG_LWIP_SNTP_MAX_SERVERS < 2", ntp2.c_str());
+            ESP_LOGI(TAG, "SNTP: custom server %s (slot0)", ntp1.c_str());
+#endif
+        } else {
+            ESP_LOGI(TAG, "SNTP: custom server %s (slot0)", ntp1.c_str());
+        }
+    } else {
+        // --- No custom servers: DHCP (slot0) + pool.ntp.org fallback (slot1) ---
+        sntp_config = ESP_NETIF_SNTP_DEFAULT_CONFIG("pool.ntp.org");
+        sntp_config.server_from_dhcp = true;
+        sntp_config.renew_servers_after_new_IP = true;
+        sntp_config.index_of_first_server = 1;  // reserve slot 0 for DHCP
+        ESP_LOGI(TAG, "SNTP: DHCP (slot0), pool.ntp.org fallback (slot1)");
+    }
+
     sntp_config.start = false;
     sntp_config.sync_cb = on_got_time;
-    sntp_config.server_from_dhcp = true;
-    sntp_config.renew_servers_after_new_IP = true;
-    sntp_config.index_of_first_server = 1;
-    sntp_config.ip_event_to_renew = IP_EVENT_STA_GOT_IP;  // TODO OR-mask? what about IP_EVENT_ETH_GOT_IP?
-    return esp_netif_sntp_init(&sntp_config);
+
+    // ip_event_to_renew accepts only a single event id (not a bitmask).
+    // Ethernet has priority; a second handler registered below covers WiFi.
+    // Only meaningful when server_from_dhcp = true, but harmless otherwise.
+    sntp_config.ip_event_to_renew = IP_EVENT_ETH_GOT_IP;
+
+    esp_err_t ret = esp_netif_sntp_init(&sntp_config);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+
+    // Second renew handler for WiFi path (covers IP_EVENT_STA_GOT_IP).
+    // Only truly needed when server_from_dhcp = true, but registering it
+    // unconditionally is harmless — renew_servers is a no-op when the
+    // static server list hasn't changed.
+    ret = esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, esp_netif_sntp_renew_servers, NULL);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register SNTP WiFi renew handler: %s", esp_err_to_name(ret));
+    }
+    return ret;
 }
 
 bool is_eth_link_up() {
@@ -644,7 +711,13 @@ esp_err_t apply_eth_ipv4_config(esp_netif_t *netif) {
     }
 
     ESP_LOGI(TAG, "ETH using static IPv4");
-    return set_static_ip(netif, eth->ip);
+    esp_err_t ret = set_static_ip(netif, eth->ip);
+    if (ret == ESP_OK && sntp_enabled && !sntp_initialized) {
+        sntp_initialized = true;
+        esp_netif_sntp_start();
+        ESP_LOGI(TAG, "SNTP started after static ETH IP assignment");
+    }
+    return ret;
 }
 
 esp_err_t apply_wifi_ipv4_config(esp_netif_t *netif) {
@@ -666,5 +739,11 @@ esp_err_t apply_wifi_ipv4_config(esp_netif_t *netif) {
     }
 
     ESP_LOGI(TAG, "WiFi using static IPv4");
-    return set_static_ip(netif, wifi->ip);
+    esp_err_t ret = set_static_ip(netif, wifi->ip);
+    if (ret == ESP_OK && sntp_enabled && !sntp_initialized) {
+        sntp_initialized = true;
+        esp_netif_sntp_start();
+        ESP_LOGI(TAG, "SNTP started after static WiFi IP assignment");
+    }
+    return ret;
 }

--- a/components/network/src/network.cpp
+++ b/components/network/src/network.cpp
@@ -382,8 +382,9 @@ void network_ip_event_handler(void *arg, esp_event_base_t event_base, int32_t ev
 
             if (sntp_enabled && !sntp_initialized) {
                 sntp_initialized = true;
-                esp_netif_sntp_start();
-                ESP_LOGI(TAG, "SNTP started on first IP event (%s)", event_id == IP_EVENT_ETH_GOT_IP ? "ETH" : "WiFi");
+                ESP_ERROR_CHECK_WITHOUT_ABORT(esp_netif_sntp_start());
+                ESP_LOGI(TAG, "SNTP started on first IP event (%s). Renew: %ds",
+                         event_id == IP_EVENT_ETH_GOT_IP ? "ETH" : "WiFi", CONFIG_LWIP_SNTP_UPDATE_DELAY / 1000);
             }
         } break;
         case IP_EVENT_STA_LOST_IP:
@@ -415,27 +416,33 @@ void network_ip_event_handler(void *arg, esp_event_base_t event_base, int32_t ev
 }
 
 void on_got_time(struct timeval *tv) {
-    struct tm *timeinfo = localtime(&tv->tv_sec);
+    struct tm timeinfo;
+    localtime_r(&tv->tv_sec, &timeinfo);
 
     char buffer[50];
-    strftime(buffer, sizeof(buffer), "%c", timeinfo);
-    auto server = esp_sntp_getservername(0) ? esp_sntp_getservername(0) : ipaddr_ntoa(esp_sntp_getserver(0));
-    ESP_LOGI(TAG, "SNTP update %s: %s", server ? server : "", buffer);
+    strftime(buffer, sizeof(buffer), "%c", &timeinfo);
+    ESP_LOGI(TAG, "SNTP update: %s", buffer);
 }
 
-/**
- * @brief Initialize SNTP.
- *
- * Server selection logic:
- *   - No custom servers configured: DHCP option 42 at slot 0, "pool.ntp.org" at slot 1
- *     (fallback). Requires CONFIG_LWIP_SNTP_MAX_SERVERS >= 2.
- *   - One custom server configured: slot 0 = server1. DHCP and fallback disabled.
- *   - Two custom servers configured: slot 0 = server1, slot 1 = server2. DHCP and
- *     fallback disabled. Requires CONFIG_LWIP_SNTP_MAX_SERVERS >= 2.
- *
- * @return ESP_OK or error code
- */
+/// @brief Initialize SNTP.
+///
+/// Server selection logic:
+///   - No custom servers configured: DHCP option 42 at slot 0, "pool.ntp.org" fallback at slot 1.
+///     Requires CONFIG_LWIP_SNTP_MAX_SERVERS >= 2.
+///   - One custom server configured: slot 0 = server1. DHCP and fallback disabled.
+///   - Two custom servers configured: slot 0 = server1, slot 1 = server2. DHCP and fallback disabled.
+///     Requires CONFIG_LWIP_SNTP_MAX_SERVERS >= 2.
+///
+/// @return ESP_OK or error code
 esp_err_t init_sntp() {
+    if (!sntp_enabled) {
+        return ESP_OK;
+    }
+
+    // IMPORTANT: esp_sntp_config_t.servers[] holds const char* pointers.
+    // `esp_netif_sntp_init()` calls strdup() internally to copy the names into its own storage (but only if
+    // `sntp_config.renew_servers_after_new_IP = true;` is set!), so the strings only need to be valid for the duration
+    // of this call — NOT for the lifetime of the SNTP service.  The std::string locals below are therefore safe.
     Config           &cfg = Config::instance();
     const std::string ntp1 = cfg.getNtpServer1();
     const std::string ntp2 = cfg.getNtpServer2();
@@ -444,40 +451,40 @@ esp_err_t init_sntp() {
     esp_sntp_config_t sntp_config;
 
     if (use_custom) {
-        // --- Custom server(s): no DHCP, no fallback ---
-        // Servers are placed starting at slot 0; DHCP slot reservation not needed.
-        sntp_config = ESP_NETIF_SNTP_DEFAULT_CONFIG(ntp1.c_str());
-        sntp_config.server_from_dhcp = false;
-        sntp_config.renew_servers_after_new_IP = false;
-        sntp_config.index_of_first_server = 0;
-
+        // Custom server(s): no DHCP, no pool.ntp.org fallback.
         if (!ntp2.empty()) {
 #if CONFIG_LWIP_SNTP_MAX_SERVERS >= 2
-            sntp_config.num_of_servers = 2;
-            sntp_config.servers[1] = ntp2.c_str();
-            ESP_LOGI(TAG, "SNTP: custom servers %s (slot0), %s (slot1)", ntp1.c_str(), ntp2.c_str());
+            sntp_config = (esp_sntp_config_t)ESP_NETIF_SNTP_DEFAULT_CONFIG_MULTIPLE(
+                2, ESP_SNTP_SERVER_LIST(ntp1.c_str(), ntp2.c_str()));
+            ESP_LOGI(TAG, "SNTP: custom servers %s, %s", ntp1.c_str(), ntp2.c_str());
 #else
+            // Only one slot available — use server1, warn about server2.
+            sntp_config =
+                (esp_sntp_config_t)ESP_NETIF_SNTP_DEFAULT_CONFIG_MULTIPLE(1, ESP_SNTP_SERVER_LIST(ntp1.c_str()));
             ESP_LOGW(TAG, "Second NTP server '%s' ignored: CONFIG_LWIP_SNTP_MAX_SERVERS < 2", ntp2.c_str());
-            ESP_LOGI(TAG, "SNTP: custom server %s (slot0)", ntp1.c_str());
+            ESP_LOGI(TAG, "SNTP: custom server %s", ntp1.c_str());
 #endif
         } else {
-            ESP_LOGI(TAG, "SNTP: custom server %s (slot0)", ntp1.c_str());
+            sntp_config =
+                (esp_sntp_config_t)ESP_NETIF_SNTP_DEFAULT_CONFIG_MULTIPLE(1, ESP_SNTP_SERVER_LIST(ntp1.c_str()));
+            ESP_LOGI(TAG, "SNTP: custom server %s", ntp1.c_str());
         }
+        sntp_config.server_from_dhcp = false;
+        sntp_config.index_of_first_server = 0;
     } else {
-        // --- No custom servers: DHCP (slot0) + pool.ntp.org fallback (slot1) ---
-        sntp_config = ESP_NETIF_SNTP_DEFAULT_CONFIG("pool.ntp.org");
+        // No custom servers: DHCP (slot 0) + pool.ntp.org fallback (slot 1).
+        sntp_config =
+            (esp_sntp_config_t)ESP_NETIF_SNTP_DEFAULT_CONFIG_MULTIPLE(1, ESP_SNTP_SERVER_LIST("pool.ntp.org"));
         sntp_config.server_from_dhcp = true;
-        sntp_config.renew_servers_after_new_IP = true;
         sntp_config.index_of_first_server = 1;  // reserve slot 0 for DHCP
-        ESP_LOGI(TAG, "SNTP: DHCP (slot0), pool.ntp.org fallback (slot1)");
+        ESP_LOGI(TAG, "SNTP: DHCP, pool.ntp.org fallback");
     }
 
+    // always required: otherwise lwIP does NOT make copies of our custom servers during initialization!
+    sntp_config.renew_servers_after_new_IP = true;
     sntp_config.start = false;
     sntp_config.sync_cb = on_got_time;
-
-    // ip_event_to_renew accepts only a single event id (not a bitmask).
-    // Ethernet has priority; a second handler registered below covers WiFi.
-    // Only meaningful when server_from_dhcp = true, but harmless otherwise.
+    // ip_event_to_renew when using DHCP. Ethernet has priority; second handler below covers WiFi.
     sntp_config.ip_event_to_renew = IP_EVENT_ETH_GOT_IP;
 
     esp_err_t ret = esp_netif_sntp_init(&sntp_config);
@@ -485,13 +492,14 @@ esp_err_t init_sntp() {
         return ret;
     }
 
-    // Second renew handler for WiFi path (covers IP_EVENT_STA_GOT_IP).
-    // Only truly needed when server_from_dhcp = true, but registering it
-    // unconditionally is harmless — renew_servers is a no-op when the
-    // static server list hasn't changed.
-    ret = esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, esp_netif_sntp_renew_servers, NULL);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to register SNTP WiFi renew handler: %s", esp_err_to_name(ret));
+    // Second renew handler for the WiFi path (IP_EVENT_ETH_GOT_IP is covered by ip_event_to_renew above).
+    // Only needed for the DHCP path, but harmless on the custom-server path since renew_servers is a no-op when the
+    // static list hasn't changed.
+    if (!use_custom) {
+        ret = esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, esp_netif_sntp_renew_servers, NULL);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to register SNTP WiFi renew handler: %s", esp_err_to_name(ret));
+        }
     }
     return ret;
 }
@@ -711,13 +719,7 @@ esp_err_t apply_eth_ipv4_config(esp_netif_t *netif) {
     }
 
     ESP_LOGI(TAG, "ETH using static IPv4");
-    esp_err_t ret = set_static_ip(netif, eth->ip);
-    if (ret == ESP_OK && sntp_enabled && !sntp_initialized) {
-        sntp_initialized = true;
-        esp_netif_sntp_start();
-        ESP_LOGI(TAG, "SNTP started after static ETH IP assignment");
-    }
-    return ret;
+    return set_static_ip(netif, eth->ip);
 }
 
 esp_err_t apply_wifi_ipv4_config(esp_netif_t *netif) {
@@ -739,11 +741,5 @@ esp_err_t apply_wifi_ipv4_config(esp_netif_t *netif) {
     }
 
     ESP_LOGI(TAG, "WiFi using static IPv4");
-    esp_err_t ret = set_static_ip(netif, wifi->ip);
-    if (ret == ESP_OK && sntp_enabled && !sntp_initialized) {
-        sntp_initialized = true;
-        esp_netif_sntp_start();
-        ESP_LOGI(TAG, "SNTP started after static WiFi IP assignment");
-    }
-    return ret;
+    return set_static_ip(netif, wifi->ip);
 }

--- a/components/network/src/network_priv.h
+++ b/components/network/src/network_priv.h
@@ -46,6 +46,9 @@ esp_err_t init_sntp(void);
 
 void network_set_hostname(esp_netif_t *interface);
 
+esp_err_t apply_eth_ipv4_config(esp_netif_t *netif);
+esp_err_t apply_wifi_ipv4_config(esp_netif_t *netif);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/network/src/network_wifi.cpp
+++ b/components/network/src/network_wifi.cpp
@@ -101,6 +101,16 @@ static void network_wifi_event_handler(void* arg, esp_event_base_t event_base, i
                     "WIFI_EVENT_STA_CONNECTED. Channel: %d, Access point: %s, BSSID: %02x:%02x:%02x:%02x:%02x:%02x",
                     s->channel, ssid, s->bssid[0], s->bssid[1], s->bssid[2], s->bssid[3], s->bssid[4], s->bssid[5]);
             }
+
+#if CONFIG_LWIP_IPV6
+            esp_err_t err = esp_netif_create_ip6_linklocal(wifi_netif);
+            if (err == ESP_OK) {
+                ESP_LOGI(TAG, "Creating IPv6 link-local address for WiFi");
+            } else if (err != ESP_ERR_INVALID_STATE) {
+                ESP_LOGW(TAG, "Failed to create IPv6 link-local address for WiFi: %s", esp_err_to_name(err));
+            }
+#endif
+
             trigger_connected_event();
 
         } break;
@@ -151,7 +161,6 @@ esp_netif_t* network_wifi_start() {
         ESP_ERROR_CHECK_WITHOUT_ABORT(
             esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &network_wifi_event_handler, NULL, NULL));
         ESP_LOGD(TAG, "Setting up wifi Storage");
-        // TODO decide on storage option: RAM or FLASH
         ESP_ERROR_CHECK_WITHOUT_ABORT(esp_wifi_set_storage(WIFI_STORAGE_RAM));
     }
     ESP_LOGI(TAG, "Setting up wifi mode as STA");

--- a/components/preferences/config.cpp
+++ b/components/preferences/config.cpp
@@ -281,27 +281,27 @@ network_cfg_t Config::getNetwork() {
     return cfg;
 }
 
-bool Config::setDnsServer(const std::string& server1, const std::string& server2) {
-    if (server1.length() > 32 || server2.length() > 32) {
-        ESP_LOGW(m_ctx, "Ignoring dns server: name too long");
-        return false;
-    }
+bool Config::setDnsServer(ip4_addr_t dns1, ip4_addr_t dns2) {
     if (!m_preferences.begin(m_prefGeneral, false)) {
         return false;
     }
-    m_preferences.putString("dns_server1", server1);
-    m_preferences.putString("dns_server2", server2);
+    m_preferences.putUInt("dns1", dns1.addr);
+    m_preferences.putUInt("dns2", dns2.addr);
 
     m_preferences.end();
     return true;
 }
 
-std::string Config::getDnsServer1() {
-    return getStringSetting(m_prefGeneral, "dns_server1", "");
+ip4_addr_t Config::getDnsServer1() {
+    ip4_addr_t addr;
+    addr.addr = getUIntSetting(m_prefGeneral, "dns1", 0);
+    return addr;
 }
 
-std::string Config::getDnsServer2() {
-    return getStringSetting(m_prefGeneral, "dns_server2", "");
+ip4_addr_t Config::getDnsServer2() {
+    ip4_addr_t addr;
+    addr.addr = getUIntSetting(m_prefGeneral, "dns2", 0);
+    return addr;
 }
 
 uint8_t Config::getVolume() {

--- a/components/preferences/config.cpp
+++ b/components/preferences/config.cpp
@@ -281,27 +281,27 @@ network_cfg_t Config::getNetwork() {
     return cfg;
 }
 
-bool Config::setDnsServer(ip4_addr_t dns1, ip4_addr_t dns2) {
+bool Config::setDnsServer(const std::string& server1, const std::string& server2) {
+    if (server1.length() > 47 || server2.length() > 47) {
+        ESP_LOGW(m_ctx, "Ignoring dns server: name too long");
+        return false;
+    }
     if (!m_preferences.begin(m_prefGeneral, false)) {
         return false;
     }
-    m_preferences.putUInt("dns1", dns1.addr);
-    m_preferences.putUInt("dns2", dns2.addr);
+    m_preferences.putString("dns_server1", server1);
+    m_preferences.putString("dns_server2", server2);
 
     m_preferences.end();
     return true;
 }
 
-ip4_addr_t Config::getDnsServer1() {
-    ip4_addr_t addr;
-    addr.addr = getUIntSetting(m_prefGeneral, "dns1", 0);
-    return addr;
+std::string Config::getDnsServer1() {
+    return getStringSetting(m_prefGeneral, "dns_server1", "");
 }
 
-ip4_addr_t Config::getDnsServer2() {
-    ip4_addr_t addr;
-    addr.addr = getUIntSetting(m_prefGeneral, "dns2", 0);
-    return addr;
+std::string Config::getDnsServer2() {
+    return getStringSetting(m_prefGeneral, "dns_server2", "");
 }
 
 uint8_t Config::getVolume() {

--- a/components/preferences/config.cpp
+++ b/components/preferences/config.cpp
@@ -240,7 +240,7 @@ bool Config::setNtpServer(const std::string& server1, const std::string& server2
 }
 
 std::string Config::getNtpServer1() {
-    return getStringSetting(m_prefGeneral, "ntp_server1", "pool.ntp.org");
+    return getStringSetting(m_prefGeneral, "ntp_server1", "");
 }
 
 std::string Config::getNtpServer2() {

--- a/components/preferences/config.cpp
+++ b/components/preferences/config.cpp
@@ -225,7 +225,7 @@ bool Config::isNtpEnabled() {
 }
 
 bool Config::setNtpServer(const std::string& server1, const std::string& server2) {
-    if (server1.length() > 32 || server2.length() > 32) {
+    if (server1.length() > 47 || server2.length() > 47) {
         ESP_LOGW(m_ctx, "Ignoring ntp server: name too long");
         return false;
     }

--- a/components/preferences/config.cpp
+++ b/components/preferences/config.cpp
@@ -251,25 +251,32 @@ bool Config::setNetwork(network_cfg_t cfg) {
     if (!m_preferences.begin(m_prefGeneral, false)) {
         return false;
     }
-    m_preferences.putBool("ip_dhcp", cfg.dhcp);
-    m_preferences.putUInt("ip_addr", cfg.ip.ip.addr);
-    m_preferences.putUInt("ip_mask", cfg.ip.netmask.addr);
-    m_preferences.putUInt("ip_gw", cfg.ip.gw.addr);
+    m_preferences.putBool("eth_dhcp", cfg.eth.dhcp);
+    m_preferences.putUInt("eth_ip", cfg.eth.ip.ip.addr);
+    m_preferences.putUInt("eth_mask", cfg.eth.ip.netmask.addr);
+    m_preferences.putUInt("eth_gw", cfg.eth.ip.gw.addr);
+
+    m_preferences.putBool("wifi_dhcp", cfg.wifi.dhcp);
+    m_preferences.putUInt("wifi_ip", cfg.wifi.ip.ip.addr);
+    m_preferences.putUInt("wifi_mask", cfg.wifi.ip.netmask.addr);
+    m_preferences.putUInt("wifi_gw", cfg.wifi.ip.gw.addr);
 
     m_preferences.end();
     return true;
 }
 
 network_cfg_t Config::getNetwork() {
-    esp_netif_ip_info_t ip;
-    memset(&ip, 0, sizeof(esp_netif_ip_info_t));
-    ip.ip.addr = getUIntSetting(m_prefGeneral, "ip_addr", 0);
-    ip.netmask.addr = getUIntSetting(m_prefGeneral, "ip_mask", 0);
-    ip.gw.addr = getUIntSetting(m_prefGeneral, "ip_gw", 0);
+    network_cfg_t cfg = {};
 
-    network_cfg_t cfg;
-    cfg.dhcp = getBoolSetting(m_prefGeneral, "ip_dhcp", true);
-    cfg.ip = ip;
+    cfg.eth.dhcp = getBoolSetting(m_prefGeneral, "eth_dhcp", true);
+    cfg.eth.ip.ip.addr = getUIntSetting(m_prefGeneral, "eth_ip", 0);
+    cfg.eth.ip.netmask.addr = getUIntSetting(m_prefGeneral, "eth_mask", 0);
+    cfg.eth.ip.gw.addr = getUIntSetting(m_prefGeneral, "eth_gw", 0);
+
+    cfg.wifi.dhcp = getBoolSetting(m_prefGeneral, "wifi_dhcp", true);
+    cfg.wifi.ip.ip.addr = getUIntSetting(m_prefGeneral, "wifi_ip", 0);
+    cfg.wifi.ip.netmask.addr = getUIntSetting(m_prefGeneral, "wifi_mask", 0);
+    cfg.wifi.ip.gw.addr = getUIntSetting(m_prefGeneral, "wifi_gw", 0);
 
     return cfg;
 }

--- a/components/preferences/config.h
+++ b/components/preferences/config.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "driver/uart.h"
+#include "lwip/ip4_addr.h"
 
 #include "ext_port_mode.h"
 #include "net_config.h"
@@ -135,14 +136,14 @@ class Config {
     network_cfg_t getNetwork();
 
     /// @brief Set static DNS server addresses
-    /// @param server1 main DNS. Max length is 32 characters.
-    /// @param server2 backup DNS. Max length is 32 characters.
+    /// @param dns1 main DNS IPv4 address.
+    /// @param dns2 backup DNS IPv4 address.
     /// @return true if server addresses could be stored
-    bool setDnsServer(const std::string& server1, const std::string& server2);
-    /// @brief Get main DNS server address.
-    std::string getDnsServer1();
-    /// @brief Get backupt DNS server address.
-    std::string getDnsServer2();
+    bool setDnsServer(ip4_addr_t dns1, ip4_addr_t dns2);
+    /// @brief Get main DNS server IPv4 address.
+    ip4_addr_t getDnsServer1();
+    /// @brief Get backup DNS server IPv4 address.
+    ip4_addr_t getDnsServer2();
 
     // -- Sound settings
 

--- a/components/preferences/config.h
+++ b/components/preferences/config.h
@@ -11,7 +11,6 @@
 #include <string>
 
 #include "driver/uart.h"
-#include "lwip/ip4_addr.h"
 
 #include "ext_port_mode.h"
 #include "net_config.h"
@@ -136,14 +135,14 @@ class Config {
     network_cfg_t getNetwork();
 
     /// @brief Set static DNS server addresses
-    /// @param dns1 main DNS IPv4 address.
-    /// @param dns2 backup DNS IPv4 address.
+    /// @param server1 main DNS. Max length is 47 characters.
+    /// @param server2 backup DNS. Max length is 47 characters.
     /// @return true if server addresses could be stored
-    bool setDnsServer(ip4_addr_t dns1, ip4_addr_t dns2);
-    /// @brief Get main DNS server IPv4 address.
-    ip4_addr_t getDnsServer1();
-    /// @brief Get backup DNS server IPv4 address.
-    ip4_addr_t getDnsServer2();
+    bool setDnsServer(const std::string& server1, const std::string& server2);
+    /// @brief Get main DNS server address.
+    std::string getDnsServer1();
+    /// @brief Get backupt DNS server address.
+    std::string getDnsServer2();
 
     // -- Sound settings
 

--- a/components/preferences/net_config.h
+++ b/components/preferences/net_config.h
@@ -13,8 +13,13 @@ extern "C" {
 #endif
 
 typedef struct {
-    bool                dhcp;
-    esp_netif_ip_info_t ip;
+    bool                dhcp;  // true = DHCP, false = static
+    esp_netif_ip_info_t ip;    // numeric IPv4 ip/netmask/gw
+} iface_net_cfg_t;
+
+typedef struct {
+    iface_net_cfg_t eth;   // Ethernet config
+    iface_net_cfg_t wifi;  // WiFi STA config
 } network_cfg_t;
 
 #ifdef __cplusplus

--- a/components/preferences/uc_events.h
+++ b/components/preferences/uc_events.h
@@ -105,6 +105,7 @@ typedef enum {
 typedef struct {
     network_kind_t connection;
     bool           eth_link;
+    bool           dhcp;
     // SSID of AP
     uint8_t ssid[33];
     // Signal strength of AP. Set to 0x00 if ethernet is connected.

--- a/components/webserver/WebServer.cpp
+++ b/components/webserver/WebServer.cpp
@@ -703,7 +703,11 @@ void WebServer::broadcastWsTxt(std::string &msg) {
     }
 }
 
+#if CONFIG_LWIP_IPV6
 esp_err_t WebServer::getRemoteIp(int fd, struct sockaddr_in6 *addr_in) {
+#else
+esp_err_t WebServer::getRemoteIp(int fd, struct sockaddr_in *addr_in) {
+#endif
     socklen_t addrlen = sizeof(*addr_in);
     if (lwip_getpeername(fd, (struct sockaddr *)addr_in, &addrlen) != -1) {
         return ESP_OK;

--- a/components/webserver/WebServer.h
+++ b/components/webserver/WebServer.h
@@ -106,7 +106,11 @@ class WebServer {
     /// @param msg text message
     void broadcastWsTxt(std::string &msg);
 
+#if CONFIG_LWIP_IPV6
     static esp_err_t getRemoteIp(int id, struct sockaddr_in6 *addr_in);
+#else
+    static esp_err_t getRemoteIp(int id, struct sockaddr_in *addr_in);
+#endif
 
     uint16_t wsClientCount();
 

--- a/doc/websocket-api.md
+++ b/doc/websocket-api.md
@@ -280,10 +280,12 @@ Enable TCP serial server:
 ```
 
 - DNS is a global configuration, not per interface.
-- dns1 and dns2 must be IPv4 addresses.
-- Too clear a DNS server: omit the `dns#` field. An empty value is not valid.
+- `dns1` and `dns2` must be IPv4 addresses.
+- Omit a field to keep the current value unchanged.
+- Set a field to an empty string to clear that DNS server.
 - Manually configured DNS servers take priority over DHCP assigned servers.
-- New DNS settings are applied immediately. Removing a DNS setting requires a reboot.
+- New DNS settings are applied immediately.
+- Removing a DNS setting requires a reboot to clear the currently active DNS server.
 
 ### Set a static IPv4 configuration
 

--- a/doc/websocket-api.md
+++ b/doc/websocket-api.md
@@ -280,9 +280,10 @@ Enable TCP serial server:
 ```
 
 - DNS is a global configuration, not per interface.
-- Too clear a DNS server: use an empty string.
+- dns1 and dns2 must be IPv4 addresses.
+- Too clear a DNS server: omit the `dns#` field. An empty value is not valid.
 - Manually configured DNS servers take priority over DHCP assigned servers.
-- The dock will automatically reboot after changing the configuration. 
+- New DNS settings are applied immediately. Removing a DNS setting requires a reboot.
 
 ### Set a static IPv4 configuration
 
@@ -328,6 +329,7 @@ Response:
     "wifi": {
         "mode": "dhcp"
     },
+    "dns1": "8.8.8.8",
     "sntp_enabled": false,
     "sntp1": "pool.ntp.org",
     "active": {
@@ -335,6 +337,7 @@ Response:
         "ip": "192.168.16.88",
         "mask": "255.255.255.0",
         "gw": "192.168.16.1",
+        "dns1": "8.8.8.8",
         "ipv6": {
             "addresses": [
                 {

--- a/doc/websocket-api.md
+++ b/doc/websocket-api.md
@@ -280,9 +280,10 @@ Enable TCP serial server:
 ```
 
 - DNS is a global configuration, not per interface.
-- `dns1` and `dns2` must be IPv4 addresses.
-- Omit a field to keep the current value unchanged.
-- Set a field to an empty string to clear that DNS server.
+- `dns1` and `dns2` must be IP address literals.
+- IPv6 DNS servers are accepted only if the firmware is built with IPv6 support.
+- Omit a `dns#` field to keep the current value unchanged.
+- Set a `dns#` field to an empty string to clear that DNS server.
 - Manually configured DNS servers take priority over DHCP assigned servers.
 - New DNS settings are applied immediately.
 - Removing a DNS setting requires a reboot to clear the currently active DNS server.

--- a/doc/websocket-api.md
+++ b/doc/websocket-api.md
@@ -264,3 +264,90 @@ Enable TCP serial server:
   "enable": true
 }
 ```
+
+## Static Network Configuration
+
+### Set DNS servers
+
+```json
+{
+    "type": "dock",
+    "id": 123,
+    "command": "set_dns",
+    "dns1": "1.1.1.1",
+    "dns2": "8.8.8.8"
+}
+```
+
+- DNS is a global configuration, not per interface.
+- Too clear a DNS server: use an empty string.
+- Manually configured DNS servers take priority over DHCP assigned servers.
+- The dock will automatically reboot after changing the configuration. 
+
+### Set a static IPv4 configuration
+
+```json
+{
+    "type": "dock",
+    "id": 123,
+    "command": "set_network",
+    "interface": "eth",
+    "mode": "static",
+    "ip": "192.168.16.88",
+    "mask": "255.255.255.0",
+    "gw": "192.168.16.1"
+}
+```
+
+- Configuration is per `interface`: `eth` or `wifi`
+- `mode`: `static` or `dhcp`
+
+### Get network configuration
+
+Request:
+```json
+{
+    "type": "dock",
+    "id": 123,
+    "command": "get_network"
+}
+```
+
+Response:
+```json
+{
+    "req_id": 123,
+    "type": "dock",
+    "msg": "get_network",
+    "eth": {
+        "mode": "static",
+        "ip": "192.168.16.88",
+        "mask": "255.255.255.0",
+        "gw": "192.168.16.1"
+    },
+    "wifi": {
+        "mode": "dhcp"
+    },
+    "sntp_enabled": false,
+    "sntp1": "pool.ntp.org",
+    "active": {
+        "interface": "eth",
+        "ip": "192.168.16.88",
+        "mask": "255.255.255.0",
+        "gw": "192.168.16.1",
+        "ipv6": {
+            "addresses": [
+                {
+                    "address": "FE80::9270:69FF:FE8D:3063",
+                    "type": "link_local"
+                },
+                {
+                    "address": "FDE4:BE4C:EBA9:D140:9270:69FF:FE8D:3063",
+                    "type": "unique_local"
+                }
+            ]
+        }
+    },
+    "code": 200
+}
+```

--- a/doc/websocket-api.md
+++ b/doc/websocket-api.md
@@ -35,7 +35,7 @@ Example request from the Core-API to send an IR code on external port 2:
   "int_side": false,
   "int_top": false,
   "ext1": false,
-  "ext2": true,
+  "ext2": true
 }
 ```
 
@@ -99,7 +99,7 @@ Example request from the Core-API to send a Sony TV volume up command for 2 seco
   "int_side": false,
   "int_top": false,
   "ext1": false,
-  "ext2": true,
+  "ext2": true
 }
 ```
 
@@ -154,9 +154,9 @@ For `mode: RS232`, the UART settings can be configured with additional fields:
   "command": "set_port_mode",
   "port": 1,
   "mode": "RS232",
-  "baud_rate": 19200
-  "data_bits": 7
-  "parity": "even"
+  "baud_rate": 19200,
+  "data_bits": 7,
+  "parity": "even",
   "stop_bits": "1.5"
 }
 ```

--- a/doc/websocket-api.md
+++ b/doc/websocket-api.md
@@ -288,6 +288,19 @@ Enable TCP serial server:
 - New DNS settings are applied immediately.
 - Removing a DNS setting requires a reboot to clear the currently active DNS server.
 
+### Set NTP servers
+
+```json
+{
+    "type": "dock",
+    "id": 123,
+    "command": "set_ntp",
+    "ntp_enabled": true,
+    "ntp1": "192.168.1.1",
+    "ntp2": "pool.ntp.org"
+}
+```
+
 ### Set a static IPv4 configuration
 
 ```json
@@ -305,6 +318,7 @@ Enable TCP serial server:
 
 - Configuration is per `interface`: `eth` or `wifi`
 - `mode`: `static` or `dhcp`
+- `gw` is optional
 
 ### Get network configuration
 
@@ -333,8 +347,8 @@ Response:
         "mode": "dhcp"
     },
     "dns1": "8.8.8.8",
-    "sntp_enabled": false,
-    "sntp1": "pool.ntp.org",
+    "ntp_enabled": true,
+    "ntp1": "pool.ntp.org",
     "active": {
         "interface": "eth",
         "ip": "192.168.16.88",

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -366,7 +366,7 @@ extern "C" void app_main(void) {
 
     // setup external ports
     auto ports = init_external_ports(&cfg, vcc_adc_unit, vcc_channel);
-    uc_fatal_error_check(network_start(), uc_errors::UC_ERROR_INIT_NET);
+    uc_fatal_error_check(network_start(cfg.isNtpEnabled()), uc_errors::UC_ERROR_INIT_NET);
     uc_error_check(init_mdns(&cfg), uc_errors::UC_ERROR_INIT_MDNS);
 
     static WebServer web;

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -12,6 +12,7 @@
 #include "esp_event.h"
 #include "esp_log.h"
 #include "esp_netif.h"
+#include "esp_sntp.h"
 #include "esp_system.h"
 #include "esp_timer.h"
 #include "lwip/ip4_addr.h"
@@ -1044,6 +1045,25 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
                     const char *dns_str = ip_addr_to_string(&dns.ip, ip_str, sizeof(ip_str));
                     if (dns_str) {
                         cJSON_AddStringToObject(active_net, "dns3", dns_str);
+                    }
+                }
+            }
+
+            if (config_->isNtpEnabled()) {
+                for (uint8_t i = 0; i < CONFIG_LWIP_SNTP_MAX_SERVERS; i++) {
+                    char key[8];
+                    snprintf(key, sizeof(key), "ntp%u", i + 1);
+                    const char *server_name = esp_sntp_getservername(i);
+                    if (server_name) {
+                        cJSON_AddStringToObject(active_net, key, server_name);
+                    } else {
+                        // IPv4 or IPv6 address
+                        char             buf[48];
+                        ip_addr_t const *ip = esp_sntp_getserver(i);
+                        server_name = ipaddr_ntoa_r(ip, buf, sizeof(buf));
+                        if (server_name != NULL) {
+                            cJSON_AddStringToObject(active_net, key, server_name);
+                        }
                     }
                 }
             }

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -11,8 +11,11 @@
 #include "esp_chip_info.h"
 #include "esp_event.h"
 #include "esp_log.h"
+#include "esp_netif.h"
 #include "esp_system.h"
 #include "esp_timer.h"
+#include "lwip/ip4_addr.h"
+#include "lwip/ip6_addr.h"
 #include "lwip/sockets.h"
 
 #include "WebServer.h"
@@ -203,6 +206,71 @@ bool cjson_get_bool(const cJSON *root, const char *field, bool *ok = NULL) {
     }
     return false;
 }
+
+#if CONFIG_LWIP_IPV6
+static const char *ipv6_addr_type_to_string(esp_ip6_addr_type_t type) {
+    switch (type) {
+        case ESP_IP6_ADDR_IS_UNKNOWN:
+            return "unknown";
+        case ESP_IP6_ADDR_IS_GLOBAL:
+            return "global";
+        case ESP_IP6_ADDR_IS_LINK_LOCAL:
+            return "link_local";
+        case ESP_IP6_ADDR_IS_SITE_LOCAL:
+            return "site_local";
+        case ESP_IP6_ADDR_IS_UNIQUE_LOCAL:
+            return "unique_local";
+        case ESP_IP6_ADDR_IS_IPV4_MAPPED_IPV6:
+            return "ipv4_mapped";
+        default:
+            return "unknown";
+    }
+}
+
+static void add_ipv6_addresses_to_json(cJSON *root, esp_netif_t *netif) {
+    if (!root || !netif) {
+        return;
+    }
+
+    esp_ip6_addr_t addresses[CONFIG_LWIP_IPV6_NUM_ADDRESSES] = {};
+    int            addr_count = esp_netif_get_all_ip6(netif, addresses);
+
+    if (addr_count <= 0) {
+        return;
+    }
+
+    cJSON *ipv6 = cJSON_CreateObject();
+    cJSON *array = cJSON_AddArrayToObject(ipv6, "addresses");
+
+    if (!array) {
+        cJSON_Delete(ipv6);
+        return;
+    }
+
+    for (int i = 0; i < addr_count; i++) {
+        const char *addr = ip6addr_ntoa((ip6_addr_t *)&addresses[i]);
+        if (!addr) {
+            continue;
+        }
+
+        cJSON *item = cJSON_CreateObject();
+        if (!item) {
+            continue;
+        }
+
+        cJSON_AddStringToObject(item, "address", addr);
+        cJSON_AddStringToObject(item, "type", ipv6_addr_type_to_string(esp_netif_ip6_get_addr_type(&addresses[i])));
+
+        cJSON_AddItemToArray(array, item);
+    }
+
+    if (cJSON_GetArraySize(array) > 0) {
+        cJSON_AddItemToObject(root, "ipv6", ipv6);
+    } else {
+        cJSON_Delete(ipv6);
+    }
+}
+#endif
 
 DockApi::DockApi(Config *config, WebServer *web, port_map_t ports)
     : config_(config),
@@ -656,45 +724,105 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         }
         code = ok ? 200 : 400;
     } else if (command == "set_network") {
-        // ‼️ Work in progress: API not finalized & static ip configuration is not yet implemented!
-        bool          ok = true;
-        network_cfg_t net_cfg;
-        net_cfg.dhcp = cjson_get_bool(root, "dhcp", &ok);
-        if (ok) {
-            std::string value = cjson_get_string(root, "ip", "");
-            if (value.empty()) {
-                ok = false;
-            } else {
-                net_cfg.ip.ip.addr = ipaddr_addr(value.c_str());
-            }
-            value = cjson_get_string(root, "mask", "255.255.255.0");
-            if (value.empty()) {
-                ok = false;
-            } else {
-                net_cfg.ip.netmask.addr = ipaddr_addr(value.c_str());
-            }
-            value = cjson_get_string(root, "gw", "");
-            if (value.empty()) {
-                ok = false;
-            } else {
-                net_cfg.ip.gw.addr = ipaddr_addr(value.c_str());
+        bool ok = true;
+
+        // interface: "eth" or "wifi"
+        const char *iface_str = cjson_get_string(root, "interface", nullptr);
+        if (!iface_str) {
+            code = 400;
+            cJSON_AddStringToObject(responseDoc, msgError, "Missing interface");
+            goto send_response;
+        }
+
+        enum { IFACE_ETH, IFACE_WIFI } iface;
+        if (strcmp(iface_str, "eth") == 0) {
+            iface = IFACE_ETH;
+        } else if (strcmp(iface_str, "wifi") == 0) {
+            iface = IFACE_WIFI;
+        } else {
+            code = 400;
+            cJSON_AddStringToObject(responseDoc, msgError, "Invalid interface");
+            goto send_response;
+        }
+
+        const char *mode_str = cjson_get_string(root, "mode", nullptr);
+        if (!mode_str) {
+            code = 400;
+            cJSON_AddStringToObject(responseDoc, msgError, "Missing mode");
+            goto send_response;
+        }
+
+        bool dhcp;
+        if (strcmp(mode_str, "dhcp") == 0) {
+            dhcp = true;
+        } else if (strcmp(mode_str, "static") == 0) {
+            dhcp = false;
+        } else {
+            code = 400;
+            cJSON_AddStringToObject(responseDoc, msgError, "Invalid mode");
+            goto send_response;
+        }
+
+        network_cfg_t    netcfg = config_->getNetwork();
+        iface_net_cfg_t *cfg = (iface == IFACE_ETH) ? &netcfg.eth : &netcfg.wifi;
+
+        cfg->dhcp = dhcp;
+
+        if (!dhcp) {
+            // Static mode: ip/mask/gw required
+            std::string ip_str = cjson_get_string(root, "ip", "");
+            std::string mask_str = cjson_get_string(root, "mask", "");
+            std::string gw_str = cjson_get_string(root, "gw", "");
+
+            if (ip_str.empty() || mask_str.empty() || gw_str.empty()) {
+                code = 400;
+                cJSON_AddStringToObject(responseDoc, msgError, "Missing ip/mask/gw for static mode");
+                goto send_response;
             }
 
-            if (ok) {
-                ok = config_->setNetwork(net_cfg);
+            cfg->ip.ip.addr = ipaddr_addr(ip_str.c_str());
+            cfg->ip.netmask.addr = ipaddr_addr(mask_str.c_str());
+            cfg->ip.gw.addr = ipaddr_addr(gw_str.c_str());
+
+            if (cfg->ip.ip.addr == IPADDR_NONE || cfg->ip.netmask.addr == IPADDR_NONE ||
+                cfg->ip.gw.addr == IPADDR_NONE) {
+                code = 400;
+                cJSON_AddStringToObject(responseDoc, msgError, "Invalid ip/mask/gw");
+                goto send_response;
             }
         }
-        code = ok ? 200 : 400;
+
+        if (!config_->setNetwork(netcfg)) {
+            code = 500;
+            cJSON_AddStringToObject(responseDoc, msgError, "Failed to save network config");
+            goto send_response;
+        }
+
+        code = 200;
+        cJSON_AddBoolToObject(responseDoc, "reboot", true);
+        schedule_restart(web, 2000);
     } else if (command == "get_network") {
-        // ‼️ Work in progress: API not finalized & static ip configuration is not yet implemented!
-        network_cfg_t net_cfg = config_->getNetwork();
+        network_cfg_t netcfg = config_->getNetwork();
 
-        cJSON_AddBoolToObject(responseDoc, "dhcp", net_cfg.dhcp);
-        if (!net_cfg.dhcp && net_cfg.ip.ip.addr && (net_cfg.ip.ip.addr != IPADDR_NONE)) {
-            cJSON_AddStringToObject(responseDoc, "ip", ip4addr_ntoa((ip4_addr_t *)&net_cfg.ip.ip));
-            cJSON_AddStringToObject(responseDoc, "mask", ip4addr_ntoa((ip4_addr_t *)&net_cfg.ip.netmask));
-            cJSON_AddStringToObject(responseDoc, "gw", ip4addr_ntoa((ip4_addr_t *)&net_cfg.ip.gw));
-        }
+        // Helper lambda to serialize one interface
+        auto add_iface = [](cJSON *root, const char *name, const iface_net_cfg_t &cfg) {
+            cJSON *obj = cJSON_CreateObject();
+            cJSON_AddItemToObject(root, name, obj);
+
+            const char *mode_str = cfg.dhcp ? "dhcp" : "static";
+            cJSON_AddStringToObject(obj, "mode", mode_str);
+
+            if (!cfg.dhcp && cfg.ip.ip.addr && cfg.ip.ip.addr != IPADDR_NONE) {
+                cJSON_AddStringToObject(obj, "ip", ip4addr_ntoa((ip4_addr_t *)&cfg.ip.ip));
+                cJSON_AddStringToObject(obj, "mask", ip4addr_ntoa((ip4_addr_t *)&cfg.ip.netmask));
+                cJSON_AddStringToObject(obj, "gw", ip4addr_ntoa((ip4_addr_t *)&cfg.ip.gw));
+            }
+        };
+
+        add_iface(responseDoc, "eth", netcfg.eth);
+        add_iface(responseDoc, "wifi", netcfg.wifi);
+
+        // DNS settings are global and not per-interface
         std::string server = config_->getDnsServer1();
         if (!server.empty()) {
             cJSON_AddStringToObject(responseDoc, "dns1", server.c_str());
@@ -703,14 +831,72 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         if (!server.empty()) {
             cJSON_AddStringToObject(responseDoc, "dns2", server.c_str());
         }
+
+        cJSON_AddBoolToObject(responseDoc, "sntp_enabled", config_->isNtpEnabled());
+        server = config_->getNtpServer1();
+        if (!server.empty()) {
+            cJSON_AddStringToObject(responseDoc, "sntp1", server.c_str());
+        }
+        server = config_->getNtpServer2();
+        if (!server.empty()) {
+            cJSON_AddStringToObject(responseDoc, "sntp2", server.c_str());
+        }
+
+        esp_netif_t *active_netif = nullptr;
+        const char  *active_if = "none";
+
+        if (is_eth_connected()) {
+            active_netif = esp_netif_get_handle_from_ifkey("ETH_DEF");
+            active_if = "eth";
+        } else if (is_wifi_up()) {
+            active_netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+            active_if = "wifi";
+        }
+
+        cJSON *active_net = cJSON_CreateObject();
+        cJSON_AddItemToObject(responseDoc, "active", active_net);
+        cJSON_AddStringToObject(active_net, "interface", active_if);
+
+        if (active_netif) {
+            esp_netif_ip_info_t ip4;
+            if (esp_netif_get_ip_info(active_netif, &ip4) == ESP_OK && ip4.ip.addr != 0 && ip4.ip.addr != IPADDR_NONE) {
+                cJSON_AddStringToObject(active_net, "ip", ip4addr_ntoa((ip4_addr_t *)&ip4.ip));
+                cJSON_AddStringToObject(active_net, "mask", ip4addr_ntoa((ip4_addr_t *)&ip4.netmask));
+                cJSON_AddStringToObject(active_net, "gw", ip4addr_ntoa((ip4_addr_t *)&ip4.gw));
+
+                esp_netif_dns_info_t dns;
+                if (esp_netif_get_dns_info(active_netif, ESP_NETIF_DNS_MAIN, &dns) == ESP_OK &&
+                    dns.ip.type == IPADDR_TYPE_V4 && dns.ip.u_addr.ip4.addr != 0) {
+                    cJSON_AddStringToObject(active_net, "dns1", ip4addr_ntoa((ip4_addr_t *)&dns.ip.u_addr.ip4));
+                }
+
+                if (esp_netif_get_dns_info(active_netif, ESP_NETIF_DNS_BACKUP, &dns) == ESP_OK &&
+                    dns.ip.type == IPADDR_TYPE_V4 && dns.ip.u_addr.ip4.addr != 0) {
+                    cJSON_AddStringToObject(active_net, "dns2", ip4addr_ntoa((ip4_addr_t *)&dns.ip.u_addr.ip4));
+                }
+
+                if (esp_netif_get_dns_info(active_netif, ESP_NETIF_DNS_FALLBACK, &dns) == ESP_OK &&
+                    dns.ip.type == IPADDR_TYPE_V4 && dns.ip.u_addr.ip4.addr != 0) {
+                    cJSON_AddStringToObject(active_net, "dns3", ip4addr_ntoa((ip4_addr_t *)&dns.ip.u_addr.ip4));
+                }
+            }
+
+#if CONFIG_LWIP_IPV6
+            add_ipv6_addresses_to_json(active_net, active_netif);
+#endif  // CONFIG_LWIP_IPV6
+        }
+
         code = 200;
     } else if (command == "set_dns") {
-        // ‼️ Work in progress: API not finalized & static ip configuration is not yet implemented!
         bool ok = true;
         if (cJSON_HasObjectItem(root, "dns1") || cJSON_HasObjectItem(root, "dns2")) {
             std::string server1 = cjson_get_string(root, "dns1", "");
             std::string server2 = cjson_get_string(root, "dns2", "");
             ok = config_->setDnsServer(server1, server2);
+            if (ok) {
+                cJSON_AddBoolToObject(responseDoc, "reboot", true);
+                schedule_restart(web, 2000);
+            }
         }
         code = ok ? 200 : 400;
     } else if (command == "get_port_modes") {

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -236,6 +236,21 @@ static bool parse_required_ipv4_addr(const cJSON *root, const char *field, ip4_a
     return true;
 }
 
+static bool parse_optional_ipv4_addr(const cJSON *root, const char *field, ip4_addr_t *addr, cJSON *responseDoc) {
+    const char *value = cjson_get_string(root, field, nullptr);
+    if (!value || strlen(value) == 0) {
+        addr->addr = IPADDR_ANY;
+        return true;
+    }
+
+    if (!parse_ipv4_addr(value, addr) || addr->addr == IPADDR_NONE) {
+        cJSON_AddStringToObject(responseDoc, msgError, "Invalid IPv4 address");
+        return false;
+    }
+
+    return true;
+}
+
 static const char *ipv4_addr_to_string(const ip4_addr_t *addr, char *buf, size_t buf_len) {
     if (!addr || !buf || buf_len == 0 || addr->addr == IPADDR_ANY || addr->addr == IPADDR_NONE) {
         return nullptr;
@@ -898,14 +913,14 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         cfg->dhcp = dhcp;
 
         if (!dhcp) {
-            // Static mode: ip/mask/gw required
+            // Static mode: ip/mask required, gw optional
             ip4_addr_t ip = {};
             ip4_addr_t mask = {};
             ip4_addr_t gw = {};
 
             if (!parse_required_ipv4_addr(root, "ip", &ip, responseDoc) ||
                 !parse_required_ipv4_addr(root, "mask", &mask, responseDoc) ||
-                !parse_required_ipv4_addr(root, "gw", &gw, responseDoc)) {
+                !parse_optional_ipv4_addr(root, "gw", &gw, responseDoc)) {
                 code = 400;
                 goto send_response;
             }

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -1047,6 +1047,27 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
                 }
             }
 
+            if (config_->isNtpEnabled()) {
+                for (uint8_t i = 0; i < CONFIG_LWIP_SNTP_MAX_SERVERS; i++) {
+                    char key[8];
+                    snprintf(key, sizeof(key), "ntp%u", i + 1);
+                    const char *server_name = esp_sntp_getservername(i);
+                    if (server_name) {
+                        cJSON_AddStringToObject(active_net, key, server_name);
+                    } else {
+                        // IPv4 or IPv6 address
+                        char             buf[48];
+                        ip_addr_t const *ip = esp_sntp_getserver(i);
+                        if (ip) {
+                            server_name = ipaddr_ntoa_r(ip, buf, sizeof(buf));
+                            if (server_name != NULL) {
+                                cJSON_AddStringToObject(active_net, key, server_name);
+                            }
+                        }
+                    }
+                }
+            }
+
 #if CONFIG_LWIP_IPV6
             add_ipv6_addresses_to_json(active_net, active_netif);
 #endif

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -903,8 +903,7 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
             std::string server2 = cjson_get_string(root, "dns2", "");
             ok = config_->setDnsServer(server1, server2);
             if (ok) {
-                cJSON_AddBoolToObject(responseDoc, "reboot", true);
-                schedule_restart(web, 2000);
+                apply_custom_dns();
             }
         }
         code = ok ? 200 : 400;

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -101,7 +101,7 @@ void fill_sysinfo_to_json(cJSON *root) {
     cJSON_AddStringToObject(root, "ssid", cfg.getWifiSsid().c_str());
     cJSON_AddNumberToObject(root, "volume", cfg.getVolume());
     cJSON_AddStringToObject(root, "uptime", get_uptime().c_str());
-    cJSON_AddBoolToObject(root, "sntp", cfg.isNtpEnabled());
+    cJSON_AddBoolToObject(root, "ntp", cfg.isNtpEnabled());
     cJSON_AddStringToObject(root, "reset_reason", getResetReason());
 
     if (cfg.isNtpEnabled()) {
@@ -872,8 +872,6 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
             schedule_restart(web, 2000);
         }
     } else if (command == "set_network") {
-        bool ok = true;
-
         // interface: "eth" or "wifi"
         const char *iface_str = cjson_get_string(root, "interface", nullptr);
         if (!iface_str) {
@@ -1045,25 +1043,6 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
                     const char *dns_str = ip_addr_to_string(&dns.ip, ip_str, sizeof(ip_str));
                     if (dns_str) {
                         cJSON_AddStringToObject(active_net, "dns3", dns_str);
-                    }
-                }
-            }
-
-            if (config_->isNtpEnabled()) {
-                for (uint8_t i = 0; i < CONFIG_LWIP_SNTP_MAX_SERVERS; i++) {
-                    char key[8];
-                    snprintf(key, sizeof(key), "ntp%u", i + 1);
-                    const char *server_name = esp_sntp_getservername(i);
-                    if (server_name) {
-                        cJSON_AddStringToObject(active_net, key, server_name);
-                    } else {
-                        // IPv4 or IPv6 address
-                        char             buf[48];
-                        ip_addr_t const *ip = esp_sntp_getserver(i);
-                        server_name = ipaddr_ntoa_r(ip, buf, sizeof(buf));
-                        if (server_name != NULL) {
-                            cJSON_AddStringToObject(active_net, key, server_name);
-                        }
                     }
                 }
             }

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -838,20 +838,24 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         ESP_ERROR_CHECK_WITHOUT_ABORT(esp_event_post(UC_DOCK_EVENTS, UC_ACTION_IDENTIFY, NULL, 0, pdMS_TO_TICKS(200)));
     } else if (command == "set_logging") {
         code = 501;  // not yet implemented
-    } else if (command == "set_sntp") {
+    } else if (command == "set_ntp") {
         bool changed = false;
-        if (cJSON_HasObjectItem(root, "sntp_server1") || cJSON_HasObjectItem(root, "sntp_server2")) {
+        if (cJSON_HasObjectItem(root, "ntp1") || cJSON_HasObjectItem(root, "ntp2")) {
             std::string old_server1 = config_->getNtpServer1();
             std::string old_server2 = config_->getNtpServer2();
-            std::string server1 = cjson_get_string(root, "sntp_server1", "");
-            std::string server2 = cjson_get_string(root, "sntp_server2", "");
+            std::string server1 = cjson_get_string(root, "ntp1", "");
+            std::string server2 = cjson_get_string(root, "ntp2", "");
+            if (server1.empty() && !server2.empty()) {
+                server1 = server2;
+                server2 = "";
+            }
             changed = (server1 != old_server1) || (server2 != old_server2);
             if (!config_->setNtpServer(server1, server2)) {
                 code = 400;
                 goto send_response;
             }
         }
-        item = cJSON_GetObjectItem(root, "sntp_enabled");
+        item = cJSON_GetObjectItem(root, "ntp_enabled");
         if (item) {
             bool old_enabled = config_->isNtpEnabled();
             bool enabled = cJSON_IsTrue(item);
@@ -986,14 +990,14 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
             cJSON_AddStringToObject(responseDoc, "dns2", dns_server.c_str());
         }
 
-        cJSON_AddBoolToObject(responseDoc, "sntp_enabled", config_->isNtpEnabled());
+        cJSON_AddBoolToObject(responseDoc, "ntp_enabled", config_->isNtpEnabled());
         std::string server = config_->getNtpServer1();
         if (!server.empty()) {
-            cJSON_AddStringToObject(responseDoc, "sntp1", server.c_str());
+            cJSON_AddStringToObject(responseDoc, "ntp1", server.c_str());
         }
         server = config_->getNtpServer2();
         if (!server.empty()) {
-            cJSON_AddStringToObject(responseDoc, "sntp2", server.c_str());
+            cJSON_AddStringToObject(responseDoc, "ntp2", server.c_str());
         }
 
         esp_netif_t *active_netif = nullptr;

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -409,13 +409,13 @@ DockApi::DockApi(Config *config, WebServer *web, port_map_t ports)
 #else
                 struct sockaddr_in addr_in;
 #endif
-                char buf[20] = {0};
+                char buf[48] = {0};
                 if (WebServer::getRemoteIp(sockfd, &addr_in) == ESP_OK) {
                     ESP_LOGI(TAG, "[%s:%d] new WS client connection: %d",
 #if CONFIG_LWIP_IPV6
                              inet_ntoa_r(addr_in.sin6_addr.un.u32_addr[3], buf, sizeof(buf)), addr_in.sin6_port,
 #else
-                             inet_ntoa_r(((struct sockaddr_in *)&addr_in)->sin_addr, buf, sizeof(buf) - 1),
+                             inet_ntoa_r(((struct sockaddr_in *)&addr_in)->sin_addr, buf, sizeof(buf)),
                              ntohs(addr_in.sin_port),
 #endif
                              sockfd);
@@ -824,22 +824,33 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
     } else if (command == "set_logging") {
         code = 501;  // not yet implemented
     } else if (command == "set_sntp") {
-        bool ok = true;
+        bool changed = false;
         if (cJSON_HasObjectItem(root, "sntp_server1") || cJSON_HasObjectItem(root, "sntp_server2")) {
+            std::string old_server1 = config_->getNtpServer1();
+            std::string old_server2 = config_->getNtpServer2();
             std::string server1 = cjson_get_string(root, "sntp_server1", "");
             std::string server2 = cjson_get_string(root, "sntp_server2", "");
+            changed = (server1 != old_server1) || (server2 != old_server2);
             if (!config_->setNtpServer(server1, server2)) {
-                ok = false;
+                code = 400;
+                goto send_response;
             }
         }
         item = cJSON_GetObjectItem(root, "sntp_enabled");
         if (item) {
+            bool old_enabled = config_->isNtpEnabled();
             bool enabled = cJSON_IsTrue(item);
+            changed = changed || (enabled != old_enabled);
             if (!config_->enableNtp(enabled)) {
-                ok = false;
+                code = 400;
+                goto send_response;
             }
         }
-        code = ok ? 200 : 400;
+
+        if (changed) {
+            cJSON_AddBoolToObject(responseDoc, "reboot", true);
+            schedule_restart(web, 2000);
+        }
     } else if (command == "set_network") {
         bool ok = true;
 
@@ -882,6 +893,7 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
 
         network_cfg_t    netcfg = config_->getNetwork();
         iface_net_cfg_t *cfg = (iface == IFACE_ETH) ? &netcfg.eth : &netcfg.wifi;
+        bool             changed = (cfg->dhcp != dhcp);
 
         cfg->dhcp = dhcp;
 
@@ -898,6 +910,8 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
                 goto send_response;
             }
 
+            changed = changed || (cfg->ip.ip.addr != ip.addr) || (cfg->ip.netmask.addr != mask.addr) ||
+                      (cfg->ip.gw.addr != gw.addr);
             cfg->ip.ip.addr = ip.addr;
             cfg->ip.netmask.addr = mask.addr;
             cfg->ip.gw.addr = gw.addr;
@@ -909,9 +923,10 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
             goto send_response;
         }
 
-        code = 200;
-        cJSON_AddBoolToObject(responseDoc, "reboot", true);
-        schedule_restart(web, 2000);
+        if (changed) {
+            cJSON_AddBoolToObject(responseDoc, "reboot", true);
+            schedule_restart(web, 2000);
+        }
     } else if (command == "get_network") {
         char          ip_str[48];
         network_cfg_t netcfg = config_->getNetwork();

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -296,11 +296,20 @@ DockApi::DockApi(Config *config, WebServer *web, port_map_t ports)
                            bool authenticated) -> esp_err_t {
         switch (type) {
             case WS_CONNECTED: {
+#if CONFIG_LWIP_IPV6
                 struct sockaddr_in6 addr_in;
-                char                buf[20] = {0};
+#else
+                struct sockaddr_in addr_in;
+#endif
+                char buf[20] = {0};
                 if (WebServer::getRemoteIp(sockfd, &addr_in) == ESP_OK) {
                     ESP_LOGI(TAG, "[%s:%d] new WS client connection: %d",
+#if CONFIG_LWIP_IPV6
                              inet_ntoa_r(addr_in.sin6_addr.un.u32_addr[3], buf, sizeof(buf)), addr_in.sin6_port,
+#else
+                             inet_ntoa_r(((struct sockaddr_in *)&addr_in)->sin_addr, buf, sizeof(buf) - 1),
+                             ntohs(addr_in.sin_port),
+#endif
                              sockfd);
                 }
 

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -207,6 +207,43 @@ bool cjson_get_bool(const cJSON *root, const char *field, bool *ok = NULL) {
     return false;
 }
 
+static bool parse_ipv4_addr(const char *value, ip4_addr_t *addr) {
+    if (!value || !addr) {
+        return false;
+    }
+
+    ip4_addr_t parsed = {};
+    if (ip4addr_aton(value, &parsed) == 0) {
+        return false;
+    }
+
+    *addr = parsed;
+    return true;
+}
+
+static bool parse_required_ipv4_addr(const cJSON *root, const char *field, ip4_addr_t *addr, cJSON *responseDoc) {
+    const char *value = cjson_get_string(root, field, nullptr);
+    if (!value || strlen(value) == 0) {
+        cJSON_AddStringToObject(responseDoc, msgError, "Missing IPv4 address field");
+        return false;
+    }
+
+    if (!parse_ipv4_addr(value, addr) || addr->addr == IPADDR_ANY || addr->addr == IPADDR_NONE) {
+        cJSON_AddStringToObject(responseDoc, msgError, "Invalid IPv4 address");
+        return false;
+    }
+
+    return true;
+}
+
+static const char *ipv4_addr_to_string(const ip4_addr_t *addr, char *buf, size_t buf_len) {
+    if (!addr || !buf || buf_len == 0 || addr->addr == IPADDR_ANY || addr->addr == IPADDR_NONE) {
+        return nullptr;
+    }
+
+    return ip4addr_ntoa_r(addr, buf, buf_len);
+}
+
 #if CONFIG_LWIP_IPV6
 static const char *ipv6_addr_type_to_string(esp_ip6_addr_type_t type) {
     switch (type) {
@@ -779,26 +816,20 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
 
         if (!dhcp) {
             // Static mode: ip/mask/gw required
-            std::string ip_str = cjson_get_string(root, "ip", "");
-            std::string mask_str = cjson_get_string(root, "mask", "");
-            std::string gw_str = cjson_get_string(root, "gw", "");
+            ip4_addr_t ip = {};
+            ip4_addr_t mask = {};
+            ip4_addr_t gw = {};
 
-            if (ip_str.empty() || mask_str.empty() || gw_str.empty()) {
+            if (!parse_required_ipv4_addr(root, "ip", &ip, responseDoc) ||
+                !parse_required_ipv4_addr(root, "mask", &mask, responseDoc) ||
+                !parse_required_ipv4_addr(root, "gw", &gw, responseDoc)) {
                 code = 400;
-                cJSON_AddStringToObject(responseDoc, msgError, "Missing ip/mask/gw for static mode");
                 goto send_response;
             }
 
-            cfg->ip.ip.addr = ipaddr_addr(ip_str.c_str());
-            cfg->ip.netmask.addr = ipaddr_addr(mask_str.c_str());
-            cfg->ip.gw.addr = ipaddr_addr(gw_str.c_str());
-
-            if (cfg->ip.ip.addr == IPADDR_NONE || cfg->ip.netmask.addr == IPADDR_NONE ||
-                cfg->ip.gw.addr == IPADDR_NONE) {
-                code = 400;
-                cJSON_AddStringToObject(responseDoc, msgError, "Invalid ip/mask/gw");
-                goto send_response;
-            }
+            cfg->ip.ip.addr = ip.addr;
+            cfg->ip.netmask.addr = mask.addr;
+            cfg->ip.gw.addr = gw.addr;
         }
 
         if (!config_->setNetwork(netcfg)) {
@@ -820,14 +851,23 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
             cJSON *obj = cJSON_CreateObject();
             cJSON_AddItemToObject(root, name, obj);
 
-            const char *mode_str = cfg.dhcp ? "dhcp" : "static";
-            cJSON_AddStringToObject(obj, "mode", mode_str);
+            cJSON_AddStringToObject(obj, "mode", cfg.dhcp ? "dhcp" : "static");
 
-            if (!cfg.dhcp && cfg.ip.ip.addr && cfg.ip.ip.addr != IPADDR_NONE) {
-                cJSON_AddStringToObject(obj, "ip", ip4addr_ntoa_r((ip4_addr_t *)&cfg.ip.ip, ip_str, sizeof(ip_str)));
-                cJSON_AddStringToObject(obj, "mask",
-                                        ip4addr_ntoa_r((ip4_addr_t *)&cfg.ip.netmask, ip_str, sizeof(ip_str)));
-                cJSON_AddStringToObject(obj, "gw", ip4addr_ntoa_r((ip4_addr_t *)&cfg.ip.gw, ip_str, sizeof(ip_str)));
+            if (!cfg.dhcp) {
+                const char *address = ipv4_addr_to_string((const ip4_addr_t *)&cfg.ip.ip, ip_str, sizeof(ip_str));
+                if (address) {
+                    cJSON_AddStringToObject(obj, "ip", address);
+                }
+
+                address = ipv4_addr_to_string((const ip4_addr_t *)&cfg.ip.netmask, ip_str, sizeof(ip_str));
+                if (address) {
+                    cJSON_AddStringToObject(obj, "mask", address);
+                }
+
+                address = ipv4_addr_to_string((const ip4_addr_t *)&cfg.ip.gw, ip_str, sizeof(ip_str));
+                if (address) {
+                    cJSON_AddStringToObject(obj, "gw", address);
+                }
             }
         };
 
@@ -835,19 +875,16 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         add_iface(responseDoc, "wifi", netcfg.wifi);
 
         // DNS settings are global and not per-interface
-        ip4_addr_t dns = config_->getDnsServer1();
-        if (dns.addr && dns.addr != IPADDR_NONE) {
-            const char *address = ip4addr_ntoa_r(&dns, ip_str, sizeof(ip_str));
-            if (address) {
-                cJSON_AddStringToObject(responseDoc, "dns1", address);
-            }
+        ip4_addr_t  dns = config_->getDnsServer1();
+        const char *address = ipv4_addr_to_string(&dns, ip_str, sizeof(ip_str));
+        if (address) {
+            cJSON_AddStringToObject(responseDoc, "dns1", address);
         }
+
         dns = config_->getDnsServer2();
-        if (dns.addr && dns.addr != IPADDR_NONE) {
-            const char *address = ip4addr_ntoa_r(&dns, ip_str, sizeof(ip_str));
-            if (address) {
-                cJSON_AddStringToObject(responseDoc, "dns2", address);
-            }
+        address = ipv4_addr_to_string(&dns, ip_str, sizeof(ip_str));
+        if (address) {
+            cJSON_AddStringToObject(responseDoc, "dns2", address);
         }
 
         cJSON_AddBoolToObject(responseDoc, "sntp_enabled", config_->isNtpEnabled());
@@ -913,19 +950,28 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         code = 200;
     } else if (command == "set_dns") {
         bool       ok = true;
-        ip4_addr_t dns1 = {0}, dns2 = {0};
+        bool       removed_dns = false;
+        ip4_addr_t dns1 = config_->getDnsServer1();
+        ip4_addr_t dns2 = config_->getDnsServer2();
 
-        const char *server = cjson_get_string(root, "dns1");
-        if (server) {
-            if (ip4addr_aton(server, &dns1) == 0) {
+        if (cJSON_HasObjectItem(root, "dns1")) {
+            const char *server = cjson_get_string(root, "dns1", "");
+            if (strlen(server) == 0) {
+                removed_dns = dns1.addr != 0;
+                dns1.addr = 0;
+            } else if (!parse_ipv4_addr(server, &dns1) || dns1.addr == IPADDR_ANY || dns1.addr == IPADDR_NONE) {
                 code = 400;
                 cJSON_AddStringToObject(responseDoc, msgError, "Invalid dns1 address");
                 goto send_response;
             }
         }
-        server = cjson_get_string(root, "dns2");
-        if (server) {
-            if (ip4addr_aton(server, &dns2) == 0) {
+
+        if (cJSON_HasObjectItem(root, "dns2")) {
+            const char *server = cjson_get_string(root, "dns2", "");
+            if (strlen(server) == 0) {
+                removed_dns = removed_dns || dns2.addr != 0;
+                dns2.addr = 0;
+            } else if (!parse_ipv4_addr(server, &dns2) || dns2.addr == IPADDR_ANY || dns2.addr == IPADDR_NONE) {
                 code = 400;
                 cJSON_AddStringToObject(responseDoc, msgError, "Invalid dns2 address");
                 goto send_response;
@@ -935,6 +981,9 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         ok = config_->setDnsServer(dns1, dns2);
         if (ok) {
             apply_custom_dns();
+            if (removed_dns) {
+                cJSON_AddBoolToObject(responseDoc, "reboot", true);
+            }
         }
         code = ok ? 200 : 400;
     } else if (command == "get_port_modes") {

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -244,6 +244,77 @@ static const char *ipv4_addr_to_string(const ip4_addr_t *addr, char *buf, size_t
     return ip4addr_ntoa_r(addr, buf, buf_len);
 }
 
+static bool parse_dns_addr(const char *value, esp_ip_addr_t *addr) {
+    if (!value || !addr || strlen(value) == 0) {
+        return false;
+    }
+
+    memset(addr, 0, sizeof(*addr));
+
+    ip4_addr_t ip4 = {};
+    if (ip4addr_aton(value, &ip4) != 0 && ip4.addr != IPADDR_ANY && ip4.addr != IPADDR_NONE) {
+        addr->type = IPADDR_TYPE_V4;
+        addr->u_addr.ip4.addr = ip4.addr;
+        return true;
+    }
+
+#if CONFIG_LWIP_IPV6
+    ip6_addr_t ip6 = {};
+    if (ip6addr_aton(value, &ip6) != 0 && !ip6_addr_isany_val(ip6)) {
+        addr->type = IPADDR_TYPE_V6;
+        memcpy(&addr->u_addr.ip6, &ip6, sizeof(addr->u_addr.ip6));
+        return true;
+    }
+#endif
+
+    return false;
+}
+
+static const char *ip_addr_to_string(const esp_ip_addr_t *addr, char *buf, size_t buf_len) {
+    if (!addr || !buf || buf_len == 0) {
+        return nullptr;
+    }
+
+    switch (addr->type) {
+        case IPADDR_TYPE_V4:
+            if (addr->u_addr.ip4.addr == IPADDR_ANY || addr->u_addr.ip4.addr == IPADDR_NONE) {
+                return nullptr;
+            }
+            return ip4addr_ntoa_r((const ip4_addr_t *)&addr->u_addr.ip4, buf, buf_len);
+
+#if CONFIG_LWIP_IPV6
+        case IPADDR_TYPE_V6:
+            if (ip6_addr_isany((const ip6_addr_t *)&addr->u_addr.ip6)) {
+                return nullptr;
+            }
+            return ip6addr_ntoa_r((const ip6_addr_t *)&addr->u_addr.ip6, buf, buf_len);
+#endif
+
+        default:
+            return nullptr;
+    }
+}
+
+static bool normalize_dns_addr_string(const char *value, std::string *normalized) {
+    if (!normalized) {
+        return false;
+    }
+
+    esp_ip_addr_t addr = {};
+    if (!parse_dns_addr(value, &addr)) {
+        return false;
+    }
+
+    char        buf[48] = {};
+    const char *str = ip_addr_to_string(&addr, buf, sizeof(buf));
+    if (!str) {
+        return false;
+    }
+
+    *normalized = str;
+    return true;
+}
+
 #if CONFIG_LWIP_IPV6
 static const char *ipv6_addr_type_to_string(esp_ip6_addr_type_t type) {
     switch (type) {
@@ -307,7 +378,7 @@ static void add_ipv6_addresses_to_json(cJSON *root, esp_netif_t *netif) {
         cJSON_Delete(ipv6);
     }
 }
-#endif
+#endif  // CONFIG_LWIP_IPV6
 
 DockApi::DockApi(Config *config, WebServer *web, port_map_t ports)
     : config_(config),
@@ -842,7 +913,7 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         cJSON_AddBoolToObject(responseDoc, "reboot", true);
         schedule_restart(web, 2000);
     } else if (command == "get_network") {
-        char          ip_str[16];
+        char          ip_str[48];
         network_cfg_t netcfg = config_->getNetwork();
 
         // Helper lambda to serialize one interface
@@ -875,16 +946,14 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         add_iface(responseDoc, "wifi", netcfg.wifi);
 
         // DNS settings are global and not per-interface
-        ip4_addr_t  dns = config_->getDnsServer1();
-        const char *address = ipv4_addr_to_string(&dns, ip_str, sizeof(ip_str));
-        if (address) {
-            cJSON_AddStringToObject(responseDoc, "dns1", address);
+        std::string dns_server = config_->getDnsServer1();
+        if (!dns_server.empty()) {
+            cJSON_AddStringToObject(responseDoc, "dns1", dns_server.c_str());
         }
 
-        dns = config_->getDnsServer2();
-        address = ipv4_addr_to_string(&dns, ip_str, sizeof(ip_str));
-        if (address) {
-            cJSON_AddStringToObject(responseDoc, "dns2", address);
+        dns_server = config_->getDnsServer2();
+        if (!dns_server.empty()) {
+            cJSON_AddStringToObject(responseDoc, "dns2", dns_server.c_str());
         }
 
         cJSON_AddBoolToObject(responseDoc, "sntp_enabled", config_->isNtpEnabled());
@@ -923,45 +992,52 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
                                         ip4addr_ntoa_r((ip4_addr_t *)&ip4.gw, ip_str, sizeof(ip_str)));
 
                 esp_netif_dns_info_t dns;
-                if (esp_netif_get_dns_info(active_netif, ESP_NETIF_DNS_MAIN, &dns) == ESP_OK &&
-                    dns.ip.type == IPADDR_TYPE_V4 && dns.ip.u_addr.ip4.addr != 0) {
-                    cJSON_AddStringToObject(active_net, "dns1",
-                                            ip4addr_ntoa_r((ip4_addr_t *)&dns.ip.u_addr.ip4, ip_str, sizeof(ip_str)));
+                if (esp_netif_get_dns_info(active_netif, ESP_NETIF_DNS_MAIN, &dns) == ESP_OK) {
+                    const char *dns_str = ip_addr_to_string(&dns.ip, ip_str, sizeof(ip_str));
+                    if (dns_str) {
+                        cJSON_AddStringToObject(active_net, "dns1", dns_str);
+                    }
                 }
 
-                if (esp_netif_get_dns_info(active_netif, ESP_NETIF_DNS_BACKUP, &dns) == ESP_OK &&
-                    dns.ip.type == IPADDR_TYPE_V4 && dns.ip.u_addr.ip4.addr != 0) {
-                    cJSON_AddStringToObject(active_net, "dns2",
-                                            ip4addr_ntoa_r((ip4_addr_t *)&dns.ip.u_addr.ip4, ip_str, sizeof(ip_str)));
+                if (esp_netif_get_dns_info(active_netif, ESP_NETIF_DNS_BACKUP, &dns) == ESP_OK) {
+                    const char *dns_str = ip_addr_to_string(&dns.ip, ip_str, sizeof(ip_str));
+                    if (dns_str) {
+                        cJSON_AddStringToObject(active_net, "dns2", dns_str);
+                    }
                 }
 
-                if (esp_netif_get_dns_info(active_netif, ESP_NETIF_DNS_FALLBACK, &dns) == ESP_OK &&
-                    dns.ip.type == IPADDR_TYPE_V4 && dns.ip.u_addr.ip4.addr != 0) {
-                    cJSON_AddStringToObject(active_net, "dns3",
-                                            ip4addr_ntoa_r((ip4_addr_t *)&dns.ip.u_addr.ip4, ip_str, sizeof(ip_str)));
+                if (esp_netif_get_dns_info(active_netif, ESP_NETIF_DNS_FALLBACK, &dns) == ESP_OK) {
+                    const char *dns_str = ip_addr_to_string(&dns.ip, ip_str, sizeof(ip_str));
+                    if (dns_str) {
+                        cJSON_AddStringToObject(active_net, "dns3", dns_str);
+                    }
                 }
             }
 
 #if CONFIG_LWIP_IPV6
             add_ipv6_addresses_to_json(active_net, active_netif);
-#endif  // CONFIG_LWIP_IPV6
+#endif
         }
 
         code = 200;
     } else if (command == "set_dns") {
-        bool       ok = true;
-        bool       removed_dns = false;
-        ip4_addr_t dns1 = config_->getDnsServer1();
-        ip4_addr_t dns2 = config_->getDnsServer2();
+        bool        ok = true;
+        bool        removed_dns = false;
+        std::string dns1 = config_->getDnsServer1();
+        std::string dns2 = config_->getDnsServer2();
 
         if (cJSON_HasObjectItem(root, "dns1")) {
             const char *server = cjson_get_string(root, "dns1", "");
             if (strlen(server) == 0) {
-                removed_dns = dns1.addr != 0;
-                dns1.addr = 0;
-            } else if (!parse_ipv4_addr(server, &dns1) || dns1.addr == IPADDR_ANY || dns1.addr == IPADDR_NONE) {
+                removed_dns = !dns1.empty();
+                dns1.clear();
+            } else if (!normalize_dns_addr_string(server, &dns1)) {
                 code = 400;
+#if CONFIG_LWIP_IPV6
                 cJSON_AddStringToObject(responseDoc, msgError, "Invalid dns1 address");
+#else
+                cJSON_AddStringToObject(responseDoc, msgError, "Invalid dns1 address or IPv6 DNS not supported");
+#endif
                 goto send_response;
             }
         }
@@ -969,11 +1045,15 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         if (cJSON_HasObjectItem(root, "dns2")) {
             const char *server = cjson_get_string(root, "dns2", "");
             if (strlen(server) == 0) {
-                removed_dns = removed_dns || dns2.addr != 0;
-                dns2.addr = 0;
-            } else if (!parse_ipv4_addr(server, &dns2) || dns2.addr == IPADDR_ANY || dns2.addr == IPADDR_NONE) {
+                removed_dns = removed_dns || !dns2.empty();
+                dns2.clear();
+            } else if (!normalize_dns_addr_string(server, &dns2)) {
                 code = 400;
+#if CONFIG_LWIP_IPV6
                 cJSON_AddStringToObject(responseDoc, msgError, "Invalid dns2 address");
+#else
+                cJSON_AddStringToObject(responseDoc, msgError, "Invalid dns2 address or IPv6 DNS not supported");
+#endif
                 goto send_response;
             }
         }
@@ -983,6 +1063,7 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
             apply_custom_dns();
             if (removed_dns) {
                 cJSON_AddBoolToObject(responseDoc, "reboot", true);
+                schedule_restart(web, 2000);
             }
         }
         code = ok ? 200 : 400;

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -811,10 +811,12 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         cJSON_AddBoolToObject(responseDoc, "reboot", true);
         schedule_restart(web, 2000);
     } else if (command == "get_network") {
+        char          ip_str[16];
         network_cfg_t netcfg = config_->getNetwork();
 
         // Helper lambda to serialize one interface
         auto add_iface = [](cJSON *root, const char *name, const iface_net_cfg_t &cfg) {
+            char   ip_str[16];
             cJSON *obj = cJSON_CreateObject();
             cJSON_AddItemToObject(root, name, obj);
 
@@ -822,9 +824,10 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
             cJSON_AddStringToObject(obj, "mode", mode_str);
 
             if (!cfg.dhcp && cfg.ip.ip.addr && cfg.ip.ip.addr != IPADDR_NONE) {
-                cJSON_AddStringToObject(obj, "ip", ip4addr_ntoa((ip4_addr_t *)&cfg.ip.ip));
-                cJSON_AddStringToObject(obj, "mask", ip4addr_ntoa((ip4_addr_t *)&cfg.ip.netmask));
-                cJSON_AddStringToObject(obj, "gw", ip4addr_ntoa((ip4_addr_t *)&cfg.ip.gw));
+                cJSON_AddStringToObject(obj, "ip", ip4addr_ntoa_r((ip4_addr_t *)&cfg.ip.ip, ip_str, sizeof(ip_str)));
+                cJSON_AddStringToObject(obj, "mask",
+                                        ip4addr_ntoa_r((ip4_addr_t *)&cfg.ip.netmask, ip_str, sizeof(ip_str)));
+                cJSON_AddStringToObject(obj, "gw", ip4addr_ntoa_r((ip4_addr_t *)&cfg.ip.gw, ip_str, sizeof(ip_str)));
             }
         };
 
@@ -832,17 +835,23 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         add_iface(responseDoc, "wifi", netcfg.wifi);
 
         // DNS settings are global and not per-interface
-        std::string server = config_->getDnsServer1();
-        if (!server.empty()) {
-            cJSON_AddStringToObject(responseDoc, "dns1", server.c_str());
+        ip4_addr_t dns = config_->getDnsServer1();
+        if (dns.addr && dns.addr != IPADDR_NONE) {
+            const char *address = ip4addr_ntoa_r(&dns, ip_str, sizeof(ip_str));
+            if (address) {
+                cJSON_AddStringToObject(responseDoc, "dns1", address);
+            }
         }
-        server = config_->getDnsServer2();
-        if (!server.empty()) {
-            cJSON_AddStringToObject(responseDoc, "dns2", server.c_str());
+        dns = config_->getDnsServer2();
+        if (dns.addr && dns.addr != IPADDR_NONE) {
+            const char *address = ip4addr_ntoa_r(&dns, ip_str, sizeof(ip_str));
+            if (address) {
+                cJSON_AddStringToObject(responseDoc, "dns2", address);
+            }
         }
 
         cJSON_AddBoolToObject(responseDoc, "sntp_enabled", config_->isNtpEnabled());
-        server = config_->getNtpServer1();
+        std::string server = config_->getNtpServer1();
         if (!server.empty()) {
             cJSON_AddStringToObject(responseDoc, "sntp1", server.c_str());
         }
@@ -869,24 +878,30 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         if (active_netif) {
             esp_netif_ip_info_t ip4;
             if (esp_netif_get_ip_info(active_netif, &ip4) == ESP_OK && ip4.ip.addr != 0 && ip4.ip.addr != IPADDR_NONE) {
-                cJSON_AddStringToObject(active_net, "ip", ip4addr_ntoa((ip4_addr_t *)&ip4.ip));
-                cJSON_AddStringToObject(active_net, "mask", ip4addr_ntoa((ip4_addr_t *)&ip4.netmask));
-                cJSON_AddStringToObject(active_net, "gw", ip4addr_ntoa((ip4_addr_t *)&ip4.gw));
+                cJSON_AddStringToObject(active_net, "ip",
+                                        ip4addr_ntoa_r((ip4_addr_t *)&ip4.ip, ip_str, sizeof(ip_str)));
+                cJSON_AddStringToObject(active_net, "mask",
+                                        ip4addr_ntoa_r((ip4_addr_t *)&ip4.netmask, ip_str, sizeof(ip_str)));
+                cJSON_AddStringToObject(active_net, "gw",
+                                        ip4addr_ntoa_r((ip4_addr_t *)&ip4.gw, ip_str, sizeof(ip_str)));
 
                 esp_netif_dns_info_t dns;
                 if (esp_netif_get_dns_info(active_netif, ESP_NETIF_DNS_MAIN, &dns) == ESP_OK &&
                     dns.ip.type == IPADDR_TYPE_V4 && dns.ip.u_addr.ip4.addr != 0) {
-                    cJSON_AddStringToObject(active_net, "dns1", ip4addr_ntoa((ip4_addr_t *)&dns.ip.u_addr.ip4));
+                    cJSON_AddStringToObject(active_net, "dns1",
+                                            ip4addr_ntoa_r((ip4_addr_t *)&dns.ip.u_addr.ip4, ip_str, sizeof(ip_str)));
                 }
 
                 if (esp_netif_get_dns_info(active_netif, ESP_NETIF_DNS_BACKUP, &dns) == ESP_OK &&
                     dns.ip.type == IPADDR_TYPE_V4 && dns.ip.u_addr.ip4.addr != 0) {
-                    cJSON_AddStringToObject(active_net, "dns2", ip4addr_ntoa((ip4_addr_t *)&dns.ip.u_addr.ip4));
+                    cJSON_AddStringToObject(active_net, "dns2",
+                                            ip4addr_ntoa_r((ip4_addr_t *)&dns.ip.u_addr.ip4, ip_str, sizeof(ip_str)));
                 }
 
                 if (esp_netif_get_dns_info(active_netif, ESP_NETIF_DNS_FALLBACK, &dns) == ESP_OK &&
                     dns.ip.type == IPADDR_TYPE_V4 && dns.ip.u_addr.ip4.addr != 0) {
-                    cJSON_AddStringToObject(active_net, "dns3", ip4addr_ntoa((ip4_addr_t *)&dns.ip.u_addr.ip4));
+                    cJSON_AddStringToObject(active_net, "dns3",
+                                            ip4addr_ntoa_r((ip4_addr_t *)&dns.ip.u_addr.ip4, ip_str, sizeof(ip_str)));
                 }
             }
 
@@ -897,14 +912,29 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
 
         code = 200;
     } else if (command == "set_dns") {
-        bool ok = true;
-        if (cJSON_HasObjectItem(root, "dns1") || cJSON_HasObjectItem(root, "dns2")) {
-            std::string server1 = cjson_get_string(root, "dns1", "");
-            std::string server2 = cjson_get_string(root, "dns2", "");
-            ok = config_->setDnsServer(server1, server2);
-            if (ok) {
-                apply_custom_dns();
+        bool       ok = true;
+        ip4_addr_t dns1 = {0}, dns2 = {0};
+
+        const char *server = cjson_get_string(root, "dns1");
+        if (server) {
+            if (ip4addr_aton(server, &dns1) == 0) {
+                code = 400;
+                cJSON_AddStringToObject(responseDoc, msgError, "Invalid dns1 address");
+                goto send_response;
             }
+        }
+        server = cjson_get_string(root, "dns2");
+        if (server) {
+            if (ip4addr_aton(server, &dns2) == 0) {
+                code = 400;
+                cJSON_AddStringToObject(responseDoc, msgError, "Invalid dns2 address");
+                goto send_response;
+            }
+        }
+
+        ok = config_->setDnsServer(dns1, dns2);
+        if (ok) {
+            apply_custom_dns();
         }
         code = ok ? 200 : 400;
     } else if (command == "get_port_modes") {


### PR DESCRIPTION
- Allow static IPv4 network configuration per interface (eth, wifi)
  - IP and subnet masks are required, gateway is optional.
- Global DNS configuration (not bound to a network interface).
  - IP or FQDN can be used for servers (max 47 characters).
  - `set_dns` WS message to configure DNS.
- Prepare IPv6 DHCP configuration.
  - Support `CONFIG_LWIP_IPV6` compile flag to disable IPv6 support.
  - All assigned IPv6 addressses are returned in the `get_network` response.
- NTP preview. If enabled:
  - no custom server(s) defined: first DHCP NTP server is used with `pool.ntp.org` as fallback
  - DHCP is disabled if one or two custom NTP servers are defined
  - No fallback server is used if a custom NTP server is used
  - IP or FQDN can be used for custom NTP servers (max 47 characters)
  - `set_ntp` message to configure NTP.
- Enhanced `set_network` and `get_network` WebSocket messages to configure and retrieve network information.

Closes #1 