### PR TITLE
refactor: replace sync log-router callbacks with queue and sender task

### DIFF
--- a/components/log_router/README.md
+++ b/components/log_router/README.md
@@ -1,0 +1,1 @@
+../../doc/log-router.md

--- a/components/log_router/include/log_router.h
+++ b/components/log_router/include/log_router.h
@@ -4,58 +4,80 @@
 
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "esp_err.h"
-#include "esp_log.h"
 #include "esp_log_level.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+
+// Maximum length of a formatted log message including null terminator.
+// Must match the message field size in log_entry_t.
+#define LOG_MESSAGE_LEN 100
+
+// Reserved level value used as a sentinel to signal the sender task to stop.
+// Must not overlap any esp_log_level_t value (which are 0–5).
+#define LOG_ENTRY_SENTINEL 0xFF
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @brief Callback function type for sending log messages to external destinations
+ * @brief A single log entry delivered through the queue.
  *
- * @param tag Log tag
- * @param level Log level
- * @param message Full log message (includes timestamp, level, tag, text)
- * @param len Length of the message
- * @param ctx User context
- * @return esp_err_t ESP_OK on success
+ * Allocated on the heap by log_router_vprintf. The receiver owns the pointer
+ * and must free() it after use.
  */
-typedef esp_err_t (*log_output_callback_t)(const char *tag, esp_log_level_t level, const char *message, size_t len,
-                                           void *ctx);
+typedef struct {
+    char     tag[11];                   ///< Null-terminated log tag, e.g. "CHARGE"
+    uint8_t  level;                     ///< esp_log_level_t cast to uint8_t
+    uint16_t len;                       ///< Length of message, not including null terminator
+    char     message[LOG_MESSAGE_LEN];  ///< Full formatted log line, null-terminated
+} log_entry_t;
 
 /**
- * @brief Initialize the log router
+ * @brief Initialise the log router.
  *
- * This sets up a custom log writer that forwards all ESP_LOG* messages to
- * registered output callbacks while keeping the default console output active.
+ * Installs a custom vprintf handler that intercepts all ESP_LOG* output.
+ * Console/UART output is always preserved. The internal queue is created but
+ * forwarding is inactive until log_router_start() is called.
  *
- * @return esp_err_t ESP_OK on success
+ * Must be called once at startup, before any task uses the log router.
+ *
+ * @return ESP_OK on success, ESP_ERR_NO_MEM if the queue cannot be created.
  */
 esp_err_t log_router_init(void);
 
 /**
- * @brief Register a callback for log output (e.g., WebSocket)
+ * @brief Start forwarding log entries to the queue.
  *
- * Multiple callbacks can be registered. Each will receive all log messages.
+ * Returns the queue handle. The caller is responsible for draining it.
+ * Entries are heap-allocated log_entry_t pointers; the receiver must free()
+ * each one after processing.
  *
- * @param callback Callback function (NULL to unregister)
- * @param ctx User context passed to callback
- * @param callback_id Output parameter to store the callback ID for later removal
- * @return esp_err_t ESP_OK on success, ESP_ERR_NO_MEM if max callbacks reached
+ * Calling start when already started is a no-op and returns the existing handle.
+ *
+ * @param[out] queue  Receives the queue handle.
+ * @return ESP_OK on success.
+ *         ESP_ERR_INVALID_STATE if log_router_init() has not been called.
+ *         ESP_ERR_INVALID_ARG if queue is NULL.
  */
-esp_err_t log_router_register_callback(log_output_callback_t callback, void *ctx, int *callback_id);
+esp_err_t log_router_start(QueueHandle_t *queue);
 
 /**
- * @brief Unregister a previously registered callback
+ * @brief Stop forwarding log entries to the queue.
  *
- * @param callback_id ID returned from log_router_register_callback
- * @return esp_err_t ESP_OK on success, ESP_ERR_NOT_FOUND if ID not found
+ * After this returns, no new entries will be enqueued. Entries already in the
+ * queue are not flushed; the caller should drain the queue before destroying it.
+ *
+ * Calling stop when already stopped is a no-op.
+ *
+ * @return ESP_OK on success.
+ *         ESP_ERR_INVALID_STATE if log_router_init() has not been called.
  */
-esp_err_t log_router_unregister_callback(int callback_id);
+esp_err_t log_router_stop(void);
 
 #ifdef __cplusplus
 }

--- a/components/log_router/log_router.c
+++ b/components/log_router/log_router.c
@@ -5,213 +5,197 @@
 #include "log_router.h"
 
 #include <stdarg.h>
-#include <stdbool.h>
+#include <stdatomic.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "esp_log.h"
 
 static const char *TAG = "LOG_ROUTER";
 
-// Maximum number of log output callbacks. At the moment we only have the UC WS API.
-#define MAX_LOG_CALLBACKS 1
+// Number of log_entry_t* pointers that can be buffered.
+// If the sender task falls behind, oldest entries are dropped (non-blocking send).
+#define LOG_QUEUE_DEPTH 64
 
-// Maximum length of formatted log message. Note: we are not using long log messages, 256 should be plenty
-#define MAX_LOG_LEN 256
+// Original vprintf installed by IDF (outputs to UART/console). Always called.
+static vprintf_like_t g_original_vprintf = NULL;
 
-// Callback entry structure
-typedef struct {
-    int                   id;
-    log_output_callback_t callback;
-    void                 *ctx;
-    bool                  active;
-} log_callback_entry_t;
+// The queue through which log_entry_t* pointers are delivered to the consumer.
+static QueueHandle_t g_log_queue = NULL;
 
-// Static storage for callbacks
-static log_callback_entry_t s_callbacks[MAX_LOG_CALLBACKS];
-static int                  s_next_id = 1;
-static bool                 s_initialized = false;
+// Atomic flag: true when the consumer has called log_router_start().
+// acquire/release ordering ensures that g_log_queue is visible before
+// forwarding begins, and that the NULL write in stop is visible after the flag drops.
+static _Atomic bool g_active = false;
 
-// Original vprintf function (outputs to console/UART)
-static int (*g_original_vprintf)(const char *fmt, va_list args) = NULL;
+static bool g_initialized = false;
 
-// Helper to parse log message and extract tag/level
-static void parse_log_message(const char *message, size_t len, char *tag, size_t tag_size, esp_log_level_t *level) {
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+static esp_log_level_t parse_level(char c) {
+    switch (c) {
+        case 'E':
+            return ESP_LOG_ERROR;
+        case 'W':
+            return ESP_LOG_WARN;
+        case 'I':
+            return ESP_LOG_INFO;
+        case 'D':
+            return ESP_LOG_DEBUG;
+        case 'V':
+            return ESP_LOG_VERBOSE;
+        default:
+            return ESP_LOG_INFO;
+    }
+}
+
+static void parse_tag(const char *message, size_t len, char *tag, size_t tag_size) {
     tag[0] = '\0';
-    *level = ESP_LOG_INFO;
-
     if (len < 10) {
         return;
     }
 
-    // Extract level (first character)
-    switch (message[0]) {
-        case 'E':
-            *level = ESP_LOG_ERROR;
-            break;
-        case 'W':
-            *level = ESP_LOG_WARN;
-            break;
-        case 'I':
-            *level = ESP_LOG_INFO;
-            break;
-        case 'D':
-            *level = ESP_LOG_DEBUG;
-            break;
-        case 'V':
-            *level = ESP_LOG_VERBOSE;
-            break;
-        default:
-            *level = ESP_LOG_INFO;
-            break;
-    }
-
-    // Find tag between ") " and ":"
+    // Format: "L (timestamp) TAG: text"
+    // Tag lives between ") " and ":"
     const char *tag_start = strchr(message, ')');
-    if (tag_start) {
+    if (!tag_start) {
+        return;
+    }
+
+    tag_start++;
+    while (*tag_start == ' ' && tag_start < message + len) {
         tag_start++;
-        while (*tag_start == ' ' && tag_start < message + len) tag_start++;
-
-        const char *tag_end = strchr(tag_start, ':');
-        if (tag_end && (tag_end - tag_start < (ptrdiff_t)tag_size)) {
-            size_t tag_len = tag_end - tag_start;
-            if (tag_len >= tag_size) {
-                tag_len = tag_size - 1;
-            }
-            strncpy(tag, tag_start, tag_len);
-            tag[tag_len] = '\0';
-        }
     }
+
+    const char *tag_end = strchr(tag_start, ':');
+    if (!tag_end) {
+        return;
+    }
+
+    size_t tag_len = (size_t)(tag_end - tag_start);
+    if (tag_len >= tag_size) {
+        tag_len = tag_size - 1;
+    }
+
+    memcpy(tag, tag_start, tag_len);
+    tag[tag_len] = '\0';
 }
 
-// Helper to check if any callbacks are active (fast path check)
-static inline bool has_active_callbacks(void) {
-    // Quick check: if next_id is still 1, no callbacks were ever registered
-    if (s_next_id == 1) {
-        return false;
-    }
+// ---------------------------------------------------------------------------
+// Custom vprintf — installed by log_router_init()
+// ---------------------------------------------------------------------------
 
-    // Check if any callback is currently active
-    for (int i = 0; i < MAX_LOG_CALLBACKS; i++) {
-        if (s_callbacks[i].active) {
-            return true;
-        }
-    }
-    return false;
-}
-
-// Custom vprintf function that forwards to multiple outputs
 static int log_router_vprintf(const char *fmt, va_list args) {
-    // Always output to console (original vprintf) - this is the common case
+    // Always forward to the original console handler first.
     int ret = 0;
     if (g_original_vprintf) {
-        va_list args_copy;
-        va_copy(args_copy, args);
-        ret = g_original_vprintf(fmt, args_copy);
-        va_end(args_copy);
+        va_list console_args;
+        va_copy(console_args, args);
+        ret = g_original_vprintf(fmt, console_args);
+        va_end(console_args);
     }
 
-    // FAST PATH: Skip all callback logic if no subscribers active
-    // This is the most common case - no extra log clients
-    if (!has_active_callbacks()) {
+    // Fast path: skip queue logic when not active.
+    // acquire: if we observe true, g_log_queue is guaranteed visible.
+    if (!atomic_load_explicit(&g_active, memory_order_acquire)) {
         return ret;
     }
 
-    // SLOW PATH: Only execute when callbacks are registered
-    // Format the message into a buffer for callbacks (don't use a static buffer for thread safety)
-    char    log_buffer[MAX_LOG_LEN];
-    va_list args_copy2;
-    va_copy(args_copy2, args);
-    int len = vsnprintf(log_buffer, sizeof(log_buffer), fmt, args_copy2);
-    va_end(args_copy2);
+    // Allocate entry. If the heap is exhausted we drop the message rather than block.
+    // The log hook must never stall the calling task.
+    log_entry_t *entry = (log_entry_t *)malloc(sizeof(log_entry_t));
+    if (!entry) {
+        return ret;
+    }
+
+    // Format into the entry's message buffer.
+    va_list fmt_args;
+    va_copy(fmt_args, args);
+    int len = vsnprintf(entry->message, LOG_MESSAGE_LEN, fmt, fmt_args);
+    va_end(fmt_args);
 
     if (len <= 0) {
+        free(entry);
         return ret;
     }
 
-    // Ensure null termination
-    if (len >= (int)sizeof(log_buffer)) {
-        len = sizeof(log_buffer) - 1;
-    }
-    log_buffer[len] = '\0';
+    entry->len = (len < LOG_MESSAGE_LEN) ? (uint16_t)len : (uint16_t)(LOG_MESSAGE_LEN - 1);
+    entry->message[entry->len] = '\0';
 
-    // Parse the message to extract tag and level
-    char            tag[32] = {0};
-    esp_log_level_t level = ESP_LOG_INFO;
+    // Parse level and tag directly from the formatted line.
+    entry->level = (uint8_t)parse_level(entry->message[0]);
+    parse_tag(entry->message, entry->len, entry->tag, sizeof(entry->tag));
 
-    parse_log_message(log_buffer, len, tag, sizeof(tag), &level);
-
-    // Forward to all registered callbacks
-    for (int i = 0; i < MAX_LOG_CALLBACKS; i++) {
-        if (s_callbacks[i].active && s_callbacks[i].callback) {
-            s_callbacks[i].callback(tag, level, log_buffer, len, s_callbacks[i].ctx);
-        }
+    // Post to queue non-blocking. Drop if full, producer must never block.
+    if (xQueueSend(g_log_queue, &entry, 0) != pdTRUE) {
+        free(entry);
     }
 
     return ret;
 }
 
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 esp_err_t log_router_init(void) {
-    if (s_initialized) {
+    if (g_initialized) {
         return ESP_OK;
     }
 
-    memset(s_callbacks, 0, sizeof(s_callbacks));
-    s_next_id = 1;
+    g_log_queue = xQueueCreate(LOG_QUEUE_DEPTH, sizeof(log_entry_t *));
+    if (!g_log_queue) {
+        return ESP_ERR_NO_MEM;
+    }
 
-    // Store the original vprintf function (default outputs to UART/console)
+    atomic_store_explicit(&g_active, false, memory_order_release);
+
     g_original_vprintf = esp_log_set_vprintf(log_router_vprintf);
+    g_initialized = true;
 
-    s_initialized = true;
     ESP_LOGI(TAG, "Log router initialized");
-
     return ESP_OK;
 }
 
-esp_err_t log_router_register_callback(log_output_callback_t callback, void *ctx, int *callback_id) {
-    if (!s_initialized) {
+esp_err_t log_router_start(QueueHandle_t *queue) {
+    if (!g_initialized) {
         return ESP_ERR_INVALID_STATE;
     }
-
-    if (!callback) {
+    if (!queue) {
         return ESP_ERR_INVALID_ARG;
     }
 
-    for (int i = 0; i < MAX_LOG_CALLBACKS; i++) {
-        if (!s_callbacks[i].active) {
-            s_callbacks[i].id = s_next_id++;
-            s_callbacks[i].callback = callback;
-            s_callbacks[i].ctx = ctx;
-            s_callbacks[i].active = true;
+    *queue = g_log_queue;
+    // ensures g_log_queue is visible to any core that observes g_active == true
+    atomic_store_explicit(&g_active, true, memory_order_release);
 
-            if (callback_id) {
-                *callback_id = s_callbacks[i].id;
-            }
-
-            ESP_LOGD(TAG, "Callback registered with ID %d", s_callbacks[i].id);
-            return ESP_OK;
-        }
-    }
-
-    ESP_LOGE(TAG, "Maximum number of callbacks reached (%d)", MAX_LOG_CALLBACKS);
-    return ESP_ERR_NO_MEM;
+    ESP_LOGI(TAG, "Log forwarding started");
+    return ESP_OK;
 }
 
-esp_err_t log_router_unregister_callback(int callback_id) {
-    if (!s_initialized) {
+esp_err_t log_router_stop(void) {
+    if (!g_initialized) {
         return ESP_ERR_INVALID_STATE;
     }
 
-    for (int i = 0; i < MAX_LOG_CALLBACKS; i++) {
-        if (s_callbacks[i].active && s_callbacks[i].id == callback_id) {
-            s_callbacks[i].active = false;
-            s_callbacks[i].callback = NULL;
-            s_callbacks[i].ctx = NULL;
+    // Flip the active flag first so no new real entries are enqueued after this point.
+    atomic_store_explicit(&g_active, false, memory_order_release);
 
-            ESP_LOGD(TAG, "Callback %d unregistered", callback_id);
-            return ESP_OK;
+    // Post a sentinel to unblock the consumer if it is waiting in xQueueReceive.
+    // Allocated on the heap like real entries so the consumer can free() it uniformly.
+    log_entry_t *sentinel = (log_entry_t *)malloc(sizeof(log_entry_t));
+    if (sentinel) {
+        memset(sentinel, 0, sizeof(log_entry_t));
+        sentinel->level = LOG_ENTRY_SENTINEL;
+        if (xQueueSend(g_log_queue, &sentinel, pdMS_TO_TICKS(100)) != pdTRUE) {
+            free(sentinel);  // queue full — task will drain and eventually idle-exit
+            ESP_LOGW(TAG, "Failed to enqueue sentinel, task will drain on next message");
         }
     }
 
-    return ESP_ERR_NOT_FOUND;
+    ESP_LOGI(TAG, "Log forwarding stopped");
+    return ESP_OK;
 }

--- a/components/webserver/WebServer.cpp
+++ b/components/webserver/WebServer.cpp
@@ -677,6 +677,9 @@ esp_err_t WebServer::sendWsTxt(int id, char *msg) {
     resp_arg->type = HTTPD_WS_TYPE_TEXT;
     resp_arg->payload = (uint8_t *)msg;
     resp_arg->len = 0;
+    // WARNING httpd_queue_work silently drops messages if queue is full in IDF 5.4!
+    // This has only been recently fixed: https://github.com/espressif/esp-idf/issues/18563
+    // https://github.com/espressif/esp-idf/commit/c911c781ae94e40d0df6596a25c53025c5f98fb5
     esp_err_t ret = httpd_queue_work(resp_arg->hd, ws_async_send, resp_arg);
     if (ret != ESP_OK) {
         free(resp_arg->payload);

--- a/doc/log-router.md
+++ b/doc/log-router.md
@@ -9,6 +9,9 @@ ESP32-S3 Dock 3 firmware to enable real-time log streaming to WebSocket clients.
 **Primary Use Case:** Real-time debugging and monitoring via WebSocket API or the upcoming web management UI without
 compromising serial console output.
 
+**Developer Feature:** Log streaming is designed for developer use and is inactive during normal operation. The
+FreeRTOS sender task and the log queue only exist while at least one WebSocket client is subscribed.
+
 ## Architecture
 
 ```
@@ -27,27 +30,44 @@ compromising serial console output.
 ┌─────────────────────────────────────────────────────────────┐
 │                  log_router_vprintf()                       │
 │  ┌───────────────────────────────────────────────────────┐  │
-│  │ FAST PATH (99%+ of runtime):                          │  │
-│  │ - Check has_active_callbacks()                        │  │
-│  │ - If false: return immediately                        │  │
-│  │ - Overhead: single integer comparison                 │  │
+│  │ FAST PATH (normal runtime, no subscribers):           │  │
+│  │ - Check g_active atomic flag                          │  │
+│  │ - If false: call original vprintf and return          │  │
+│  │ - Overhead: single atomic load                        │  │
 │  └───────────────────────────────────────────────────────┘  │
 │  ┌───────────────────────────────────────────────────────┐  │
-│  │ SLOW PATH (when subscribers active):                  │  │
-│  │ - Format message to buffer                            │  │
+│  │ SLOW PATH (when queue is active):                     │  │
+│  │ - Always call original vprintf (UART/console)         │  │
+│  │ - Format message to fixed-size buffer                 │  │
 │  │ - Parse tag and level                                 │  │
-│  │ - Forward to all registered callbacks                 │  │
+│  │ - Allocate log_entry_t and post to FreeRTOS queue     │  │
+│  │ - Drop silently if queue is full (non-blocking)       │  │
 │  └───────────────────────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────────┘
-                            │
-            ┌───────────────┴───────────────┐
-            │                               │
-            ▼                               ▼
-┌───────────────────────┐       ┌───────────────────────┐
-│  Original vprintf     │       │  Registered Callbacks │
-│  (Console/UART)       │       │  - WebSocket (DockApi)│
-│  ALWAYS ACTIVE        │       │  - Syslog (future)    │
-└───────────────────────┘       └───────────────────────┘
+          │                              │
+          ▼                              ▼
+┌──────────────────┐          ┌──────────────────────────────┐
+│ Original vprintf │          │  FreeRTOS Queue              │
+│ (Console/UART)   │          │  (LOG_QUEUE_DEPTH = 64)      │
+│ ALWAYS ACTIVE    │          └──────────────�───────────────┘
+└──────────────────┘                        │
+                                            │ xQueueReceive(portMAX_DELAY)
+                                            ▼
+                               ┌─────────────────────────────┐
+                               │  logSenderTask (DockApi)    │
+                               │  - Lazy: exists only while  │
+                               │    subscribers > 0          │
+                               │  - Blocks on portMAX_DELAY  │
+                               │  - Exits on sentinel entry  │
+                               └─────────────────────────────┘
+                                            │
+                                            ▼
+                               ┌─────────────────────────────┐
+                               │  sendLogToSubscribers()     │
+                               │  - Snapshot FD list         │
+                               │  - Stack-buffer JSON build  │
+                               │  - Send to ≤4 WS clients    │
+                               └─────────────────────────────┘
 ```
 
 ## Component Structure
@@ -63,35 +83,37 @@ components/
 
 ### Files
 
-| File             | Purpose                                         | Language |
-|------------------|-------------------------------------------------|----------|
-| `log_router.h`   | Public API header with callback type definition | C        |
-| `log_router.c`   | Implementation with vprintf interception        | C        |
-| `CMakeLists.txt` | ESP-IDF component registration                  | CMake    |
+| File             | Purpose                                              | Language |
+|------------------|------------------------------------------------------|----------|
+| `log_router.h`   | Public API header with `log_entry_t` type definition | C        |
+| `log_router.c`   | Implementation with vprintf interception and queue   | C        |
+| `CMakeLists.txt` | ESP-IDF component registration                       | CMake    |
 
 ## Public API
 
 ### Type Definitions
 
 ```c
-typedef esp_err_t (*log_output_callback_t)(
-    const char *tag, 
-    esp_log_level_t level, 
-    const char *message, 
-    size_t len,
-    void *ctx
-);
+// Reserved level value used as a queue sentinel to signal logSenderTask to stop.
+// Must not overlap any esp_log_level_t value (0–5).
+#define LOG_ENTRY_SENTINEL 0xFF
+
+typedef struct {
+    char     tag[32];       // Extracted log tag, e.g. "API", "wifi"
+    uint8_t  level;         // esp_log_level_t or LOG_ENTRY_SENTINEL
+    uint16_t len;           // Length of message string
+    char     message[100];  // Formatted log text, truncated to LOG_MSG_MAX_LEN
+} log_entry_t;
 ```
 
-**Callback Parameters:**
+### Constants
 
-- `tag`: Extracted log tag (e.g., "wifi", "API", "CHARGE")
-- `level`: ESP log level (ESP_LOG_ERROR, ESP_LOG_WARN, etc.)
-- `message`: Full formatted log message including timestamp, level, tag, and log
-- `len`: Length of the message string
-- `ctx`: User context pointer passed during registration
-
-**Return:** `ESP_OK` on success
+| Constant          | Value | Rationale                                                                 |
+|-------------------|-------|---------------------------------------------------------------------------|
+| `LOG_MESSAGE_LEN` | 100   | Caps per-entry heap allocation and queue memory footprint                 |
+| `LOG_QUEUE_DEPTH` | 64    | Absorbs short bursts; entries are freed immediately after use             |
+| `MAX_WS_LOG_SUBS` | 2     | Hard cap on concurrent log streaming WebSocket clients                    |
+| `WS_LOG_DELAY_MS` | 100   | Delay in ms between sending WebSocket log messages to avoid dropping msgs |
 
 ### Functions
 
@@ -101,7 +123,8 @@ typedef esp_err_t (*log_output_callback_t)(
 esp_err_t log_router_init(void);
 ```
 
-Initializes the log router by intercepting ESP-IDF's vprintf function. Must be called before registering callbacks.
+Initializes the log router by intercepting ESP-IDF's vprintf function. Must be called once at startup before
+`log_router_start()`. Does **not** activate log forwarding — the queue is not created until `log_router_start()`.
 
 **Returns:**
 
@@ -110,58 +133,57 @@ Initializes the log router by intercepting ESP-IDF's vprintf function. Must be c
 
 **Side Effects:**
 
-- Calls `esp_log_set_vprintf()` to intercept all log output
-- Original vprintf is preserved and always called (console output never lost)
+- Calls `esp_log_set_vprintf()` to intercept all log output.
+- Original vprintf is preserved and always called (console output never lost).
+- Sets the `g_active` atomic flag to `false`; the fast path is taken for every log call until `log_router_start()`.
 
-#### `log_router_register_callback()`
+#### `log_router_start()`
 
 ```c
-esp_err_t log_router_register_callback(
-    log_output_callback_t callback, 
-    void *ctx, 
-    int *callback_id
-);
+esp_err_t log_router_start(QueueHandle_t *queue_out);
 ```
 
-Registers a callback to receive all log messages.
+Creates the FreeRTOS log queue and activates log forwarding. Called by `DockApi` when the first WebSocket client
+subscribes to log events. Idempotent: if called while already started, returns the existing queue handle.
 
 **Parameters:**
 
-- `callback`: Function pointer to receive log messages (required, cannot be NULL)
-- `ctx`: User context passed to callback on each invocation
-- `callback_id`: Output parameter to store callback ID for later unregistration
+- `queue_out`: Output parameter; receives the queue handle to be passed to `logSenderTask`.
 
 **Returns:**
 
 - `ESP_OK`: Success
-- `ESP_ERR_INVALID_STATE`: Log router not initialized
-- `ESP_ERR_INVALID_ARG`: Callback is NULL
-- `ESP_ERR_NO_MEM`: Maximum callbacks reached (MAX_LOG_CALLBACKS)
+- `ESP_ERR_INVALID_STATE`: Not initialized
+- `ESP_ERR_NO_MEM`: Queue creation failed
 
-**Example:**
+**Side Effects:**
 
-```c
-int callback_id;
-log_router_register_callback(my_callback, my_context, &callback_id);
-```
+- Creates a FreeRTOS queue of depth `LOG_QUEUE_DEPTH` holding `log_entry_t *` pointers.
+- Sets `g_active` to `true`; the slow path is taken for subsequent log calls.
 
-#### `log_router_unregister_callback()`
+#### `log_router_stop()`
 
 ```c
-esp_err_t log_router_unregister_callback(int callback_id);
+esp_err_t log_router_stop(void);
 ```
 
-Unregisters a previously registered callback.
-
-**Parameters:**
-
-- `callback_id`: ID returned from `log_router_register_callback()`
+Deactivates log forwarding and signals `logSenderTask` to exit cleanly via a sentinel queue entry. Called by `DockApi`
+when the last WebSocket subscriber disconnects or unsubscribes.
 
 **Returns:**
 
 - `ESP_OK`: Success
-- `ESP_ERR_INVALID_STATE`: Log router not initialized
-- `ESP_ERR_NOT_FOUND`: Callback ID not found
+- `ESP_ERR_INVALID_STATE`: Not initialized or not started
+
+**Side Effects:**
+
+1. Sets `g_active` to `false` atomically; no new real entries are enqueued after this point.
+2. Allocates a sentinel `log_entry_t` with `level = LOG_ENTRY_SENTINEL` and posts it to the queue.
+3. `logSenderTask` dequeues the sentinel, performs a final drain, and calls `vTaskDelete(NULL)`.
+
+If the queue is full when the sentinel is posted, `log_router_stop()` logs a warning and returns. The sender task
+will remain blocked until a real entry is eventually dequeued to make room, at which point the caller's destructor
+fallback (`vTaskDelete`) provides the safety net.
 
 ## Design Decisions
 
@@ -169,66 +191,96 @@ Unregisters a previously registered callback.
 
 **Rationale:**
 
-- IDF `ESP_LOG*` functions are used in the project
-- `esp_log_set_vprintf()` is used in ESP-IDF 5.x API
-- Returns original vprintf function pointer for chaining
-- Minimal overhead when properly optimized
+- IDF `ESP_LOG*` functions are used throughout the project.
+- `esp_log_set_vprintf()` is the correct IDF 5.x interception point.
+- Returns original vprintf function pointer, which is stored and always called (UART output never lost).
+- Minimal overhead when `g_active` is false (single atomic load).
+
+### Queue-Based Fan-Out Instead of Synchronous Callbacks
+
+**Decision:** Replace synchronous callbacks with a FreeRTOS queue consumed by a dedicated sender task.
+
+**Rationale:**
+
+The previous design executed callbacks synchronously inside the vprintf hook. This meant any slow operation
+(WebSocket send, mutex contention) directly delayed every subsequent log call system-wide. The queue design decouples
+the logging context from I/O:
+
+| Aspect              | Callback design                        | Queue design                              |
+|---------------------|----------------------------------------|-------------------------------------------|
+| vprintf hook work   | Format + parse + send (slow path)      | Format + parse + `xQueueSend` (fast)      |
+| Blocking risk       | Yes — if WS send queue full            | No — `xQueueSend` with 0 timeout, drops   |
+| Sender task exists  | Always (registered at startup)         | Only while subscribers > 0                |
+| Shutdown            | `log_router_unregister_callback()`     | Sentinel entry triggers self-deletion     |
 
 ### Fast Path Optimization
 
-**Decision:** Implement early-exit fast path when no callbacks are active.
+**Decision:** Atomic `g_active` flag checked first in `log_router_vprintf()`.
 
 **Rationale:**
 
-- Log streaming is inactive 99%+ of runtime
-- Every log call incurs overhead only when subscribers exist
-- Critical for embedded system with limited CPU resources
+- Log forwarding is inactive during the entire normal operation lifetime of the device.
+- An atomic load on a false flag costs one instruction and does not touch the queue or any heap memory.
+- No FreeRTOS primitives are touched in the fast path.
 
 ### Console Output Always Active
 
-**Decision:** Original vprintf is always called, console output cannot be disabled.
+**Decision:** Original vprintf is always called regardless of `g_active`.
 
 **Rationale:**
 
-- Serial console is critical for debugging and recovery
-- Log router is additive, not replacement
-- Prevents accidental loss of console access
+- Serial console is critical for debugging and recovery.
+- Log router is additive, not a replacement.
+- Prevents accidental loss of console access during development.
 
-### Callback Execution in Logging Context
+### Lazy Task Lifecycle
 
-**Decision:** Callbacks execute synchronously within the vprintf call.
-
-**Rationale:**
-
-- Simpler implementation
-- No queue management overhead
-- WebSocket sending is already async (httpd work queue)
-
-**Trade-offs:**
-
-- **Pro:** No buffer management, no message loss due to queue overflow
-- **Con:** Blocking if callback is slow
-
-**Mitigation:** `DockApi::sendLogToSubscribers()` uses non-blocking mutex take with timeout.
-
-**Future Improvement:** If performance becomes an issue, implement a FreeRTOS queue or ring-buffer with a dedicated
-sender task.
-
-### Message Parsing in Router
-
-**Decision:** Log router parses messages to extract tag and level, not just forward raw text.
+**Decision:** `logSenderTask` is created when the first subscriber enables log events and self-deletes when the last
+subscriber is gone.
 
 **Rationale:**
 
-- Callbacks receive structured metadata (tag, level) without re-parsing
-- Enables filtering by tag or level in callbacks
-- Consistent parsing logic across all callbacks
+- Log streaming is a developer-only feature; normal firmware operation must not pay any scheduler cost for it.
+- A task blocked on `portMAX_DELAY` with no queue to read from is still a live TCB consuming heap and a scheduler
+  slot. Creating it only on demand eliminates this cost entirely.
+- `portMAX_DELAY` in `xQueueReceive` is correct: between real log messages (typically 10+ seconds apart in normal
+  operation) the task must be completely invisible to the scheduler.
+
+### Sentinel-Based Shutdown
+
+**Decision:** `log_router_stop()` posts a `LOG_ENTRY_SENTINEL` entry to the queue to signal `logSenderTask` to exit.
+
+**Rationale:**
+
+Task notification (`xTaskNotifyGive`) was considered but has a fundamental flaw: the notification check occurs at
+the top of the loop, so if the task is blocked in `xQueueReceive(portMAX_DELAY)` with no pending messages, it will
+not wake up to check the notification until the next real log message arrives — which may be never. The sentinel
+approach guarantees immediate wakeup because it is delivered through the same queue the task is already waiting on.
+
+External `vTaskDelete` was also considered. While `vTaskDelete` from outside is supported by FreeRTOS, it introduces
+two narrow but real correctness hazards:
+
+1. If deletion fires while `sendLogToSubscribers` holds `log_subscribers_mutex_`, that mutex is permanently locked.
+2. The current `log_entry_t *` on the task stack leaks without `free()`.
+
+The sentinel avoids both by letting the task exit cleanly at a safe point after releasing all resources.
+
+### Message Parsing in the vprintf Hook
+
+**Decision:** Tag and level are extracted inside `log_router_vprintf()`, not in the sender task.
+
+**Rationale:**
+
+- The formatted message string is already available in the hook.
+- Parsing once here avoids re-parsing in every consumer.
+- The `log_entry_t` carries structured metadata (tag, level, timestamp) so `sendLogToSubscribers` can build JSON
+  directly without string scanning.
 
 **Parsed Format:** `<LEVEL> (<TIMESTAMP>) <TAG>: <TEXT>`
 
 **Example:** `I (273131) CHARGE: 0 mV`
 
-- Level: `ESP_LOG_INFO`
+- Level: `ESP_LOG_INFO` → `'I'`
 - Timestamp: `273131` ms
 - Tag: `CHARGE`
 - Text: `0 mV`
@@ -241,33 +293,34 @@ sender task.
 ┌─────────────────────────────────────────────────────────────┐
 │                    DockApi (ucd_api.cpp)                    │
 │  ┌───────────────────────────────────────────────────────┐  │
-│  │ log_callback_id_                                      │  │
-│  │ log_subscribers_ (std::set<int>)                      │  │
-│  │ log_subscribers_mutex_                                │  │
+│  │ log_subscribers_       (std::set<int>, max 4 FDs)     │  │
+│  │ log_subscribers_mutex_ (SemaphoreHandle_t)            │  │
+│  │ log_sender_task_handle_(TaskHandle_t, nullptr at rest)│  │
+│  │ log_queue_             (QueueHandle_t, nullptr at rest│  │
 │  └───────────────────────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────────┘
          │
-         │ log_router_register_callback(logCallback, this, &id)
+         │ handleEnableLogEvents(): first subscriber
+         │   → log_router_start(&log_queue_)
+         │   → xTaskCreate(logSenderTask)
          ▼
 ┌─────────────────────────────────────────────────────────────┐
-│                   Log Router                                │
-│  Forwards all ESP_LOG* messages to logCallback()            │
+│                   Log Router Queue                          │
+│  log_router_vprintf() enqueues log_entry_t* (non-blocking)  │
 └─────────────────────────────────────────────────────────────┘
          │
-         │ Callback invokes sendLogToSubscribers()
+         │ xQueueReceive(portMAX_DELAY)
          ▼
 ┌─────────────────────────────────────────────────────────────┐
-│              sendLogToSubscribers()                         │
-│  - Parse timestamp from message                             │
-│  - Trim whitespace from text                                │
-│  - Build JSON with cJSON (auto-escaping)                    │
-│  - Send to all subscribers via WebServer::sendWsTxt()       │
+│                 logSenderTask                               │
+│  - Blocks on portMAX_DELAY — zero scheduler cost at rest    │
+│  - Detects LOG_ENTRY_SENTINEL → drain → vTaskDelete(NULL)   │
 └─────────────────────────────────────────────────────────────┘
          │
-         │ Async send via httpd work queue
+         │ sendLogToSubscribers()
          ▼
 ┌─────────────────────────────────────────────────────────────┐
-│              WebSocket Clients                              │
+│              WebSocket Clients (≤ MAX_WS_LOG_SUBS = 4)      │
 │  Receive: {"type":"event","msg":"log","level":"I",...}      │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -276,20 +329,29 @@ sender task.
 
 **Data Structures in `DockApi`:**
 
-```c
-std::set<int> log_subscribers_;           // WebSocket socket FDs
-SemaphoreHandle_t log_subscribers_mutex_; // Protects subscriber set
-int log_callback_id_;                     // Log router callback ID
+```cpp
+std::set<int>     log_subscribers_;           // WebSocket socket FDs (max 4)
+SemaphoreHandle_t log_subscribers_mutex_;     // Protects subscriber set
+TaskHandle_t      log_sender_task_handle_;    // nullptr when inactive
+QueueHandle_t     log_queue_;                 // nullptr when inactive
 ```
 
 **Lifecycle:**
 
-1. **Constructor:** Initialize log router, register callback
-2. **Client connects:** Not yet subscribed
-3. **Client sends `enable_log_events: true`:** Add to `log_subscribers_`
-4. **Client sends `enable_log_events: false`:** Remove from `log_subscribers_`
-5. **Client disconnects:** Automatically removed in `WS_DISCONNECTED` handler
-6. **Destructor:** Unregister callback, delete mutex
+1. **Constructor:** `log_router_init()` is called. No task or queue is created.
+2. **Client connects:** Not yet subscribed; `log_queue_` remains `nullptr`; fast path active.
+3. **First client sends `enable_log_events: true`:**
+   - Add FD to `log_subscribers_`.
+   - Call `log_router_start(&log_queue_)` — queue created, `g_active` set to `true`.
+   - Call `xTaskCreate(logSenderTask)` — task created and immediately blocks on queue.
+4. **Additional clients subscribe:** Add FD to `log_subscribers_`. Queue and task already exist.
+5. **Client sends `enable_log_events: false`:** Remove FD. If last subscriber, trigger stop sequence.
+6. **Client disconnects (`WS_DISCONNECTED`):** Remove FD. If last subscriber, trigger stop sequence.
+7. **Stop sequence (last subscriber gone):**
+   - Call `log_router_stop()` — sets `g_active` false, posts sentinel to queue.
+   - `logSenderTask` dequeues sentinel, drains queue, calls `vTaskDelete(NULL)`.
+   - `log_sender_task_handle_` and `log_queue_` are nulled by the task and caller respectively.
+8. **Destructor:** Calls `log_router_stop()` if queue still active, then force-kills task if still alive after 50 ms.
 
 ### WebSocket API
 
@@ -311,9 +373,8 @@ int log_callback_id_;                     // Log router callback ID
 ```json
 {
   "type": "dock",
-  "id": 101,
-  "command": "enable_log_events",
-  "enable": true,
+  "req_id": 100,
+  "msg": "enable_log_events",
   "code": 200
 }
 ```
@@ -325,7 +386,7 @@ int log_callback_id_;                     // Log router callback ID
 ```json
 {
   "type": "dock",
-  "id": 102,
+  "id": 101,
   "command": "enable_log_events",
   "enable": false
 }
@@ -335,10 +396,10 @@ int log_callback_id_;                     // Log router callback ID
 
 ```json
 {
-   "type": "dock",
-   "req_id": 101,
-   "msg": "enable_log_events",
-   "code": 200
+  "type": "dock",
+  "req_id": 101,
+  "msg": "enable_log_events",
+  "code": 200
 }
 ```
 
@@ -394,126 +455,133 @@ int log_callback_id_;                     // Log router callback ID
 4. Skip leading spaces after `:`
 5. Trim leading whitespace (space, tab, CR, LF)
 6. Trim trailing whitespace (space, tab, CR, LF)
-7. Truncate to 500 characters max
-
-#### JSON Escaping
-
-**Decision:** No manual JSON escaping required.
-
-**Rationale:** cJSON automatically escapes special characters when serializing:
-
-- `"` → `\"`
-- `\` → `\\`
-- Control characters → `\uXXXX` or escaped sequences
-
-**Note:** Newlines, tabs, and carriage returns within text are preserved (not replaced with spaces) to maintain original
-log message integrity.
+7. Truncate to `LOG_MSG_MAX_LEN` (100) characters
 
 ## Performance Considerations
 
-### Fast Path (No Subscribers)
+### Fast Path (No Subscribers, Normal Runtime)
 
 **Overhead per log call:**
 
-- 1 integer comparison: `s_next_id == 1`
-- No memory operations
-- No string formatting
-- No callback dispatch
+- 1 atomic load: `atomic_load(&g_active)`
+- If false: call original vprintf and return
+- No memory operations, no queue interaction, no task wakeup
 
-**Impact:** Negligible (< 1% CPU overhead)
+**Impact:** Negligible. This is the path taken for 100% of log calls during normal device operation.
 
 ### Slow Path (Subscribers Active)
 
-**Overhead per log call:**
+**Overhead per log call inside `log_router_vprintf()`:**
 
-1. `va_copy` × 2 (for original vprintf and callback formatting)
-2. `vsnprintf` to format message (256 byte buffer)
-3. String parsing (tag, level extraction)
-4. Mutex take/give for subscriber list
-5. cJSON object creation and serialization
-6. WebSocket send for each subscriber (async via httpd queue)
+1. Call original vprintf (UART output — always done regardless)
+2. `va_copy` to re-use the `va_list` for queue formatting
+3. `vsnprintf` into 100-byte buffer
+4. String parsing (tag, level extraction)
+5. `malloc(sizeof(log_entry_t))` + fill
+6. `xQueueSend` with 0 timeout (non-blocking)
 
-**Mitigation:**
+**Overhead in `logSenderTask`, `sendLogToSubscribers` (off the logging critical path):**
 
-- Small buffer size (256 bytes) reduces formatting time
-- Non-blocking mutex with 5ms timeout prevents deadlocks
-- WebSocket sending is asynchronous (httpd work queue)
-- Message truncation at 500 characters limits JSON size
+1. `xQueueReceive(portMAX_DELAY)` — zero CPU when idle
+2. `cJSON_PrintUnformatted`
+3. `WebServer::sendWsTxt()` for each subscriber (async via httpd work queue)
+4. `free(entry)`
+
+**Key property:** Steps 1–4 in the vprintf hook complete in bounded, short time. Steps in `logSenderTask` run
+asynchronously and cannot delay the logging caller.
 
 ### Thread Safety
 
 **Critical Sections:**
 
-1. `log_subscribers_mutex_` protects `log_subscribers_` set
-2. Callback registration uses static array with implicit protection (init happens once at startup)
+1. `g_active` — `_Atomic bool`, accessed with `memory_order_acquire/release`. No mutex needed.
+2. `log_subscribers_mutex_` — protects `log_subscribers_` set in `DockApi`. Acquired with 5 ms timeout in the
+   sender task (not in the vprintf hook).
+3. Queue — FreeRTOS queue is inherently thread-safe; `xQueueSend` (0 timeout) in vprintf hook,
+   `xQueueReceive` (portMAX_DELAY) in sender task.
 
 **Lock Ordering:**
 
-- Always acquire `log_subscribers_mutex_` before any WebSocket operations
-- Timeout-based acquisition prevents deadlocks (5ms, best effort to minimally block the log context)
+- `log_subscribers_mutex_` is never held while calling into the log router.
+- The vprintf hook never acquires `log_subscribers_mutex_`.
+- No nested lock acquisition exists in the current design.
 
 **Reentrancy:**
 
-- `log_router_vprintf()` can be called from any task/context
-- Stack buffer is thread-safe, since `vprintf` might not be serialized for every low-level log message or when logging
-  from multiple cores.
+- `log_router_vprintf()` can be called from any task or ISR context (subject to IDF log constraints).
+- The vprintf hook uses only stack locals and atomic operations — fully reentrant.
 
 ## Constraints and Limitations
 
 ### Hard Limits
 
-| Parameter           | Value          | Rationale                                             |
-|---------------------|----------------|-------------------------------------------------------|
-| `MAX_LOG_CALLBACKS` | 1              | Only WebSocket API currently uses it                  |
-| `MAX_LOG_LEN`       | 256 bytes      | Fits most log messages, reduces stack usage           |
-| Message truncation  | 500 characters | Safety feature to prevent excessive WebSocket payload |
-| Mutex timeout       | 5ms            | Prevents blocking in logging path                     |
+| Parameter         | Value | Rationale                                                                           |
+|-------------------|-------|-------------------------------------------------------------------------------------|
+| `LOG_MSG_MAX_LEN` | 100   | Bounds heap allocation per entry; most messages fit comfortably                     |
+| `LOG_QUEUE_DEPTH` | 64    | Absorbs log bursts; at 100 bytes/entry = ~6 KB peak heap use                        |
+| `MAX_WS_LOG_SUBS` | 2     | Prevents unbounded FD set growth, slow message delivery; covers developer use cases |
+| Mutex timeout     | 5 ms  | Prevents blocking in sender task; best-effort delivery                              |
+
+The maximum number of log stream clients has been limited to two for an efficient message delivery. The more clients,
+the slower message delivery gets (especially during log bursts, like port detection).  
+The main issue is within `WebServer::sendWsTxt()`: messages are sent async using `httpd_queue_work`, which is using an
+internal work queue. Messages are silently dropped if the queue is full. At the moment the only "workaround" is using
+it in blocking mode, which defeats the async requirement.
+
+This behavior has only been recently fixed:
+<https://github.com/espressif/esp-idf/commit/c911c781ae94e40d0df6596a25c53025c5f98fb5>
 
 ### Known Limitations
 
-1. **Synchronous Callbacks:** Callbacks execute in the logging context. If a callback blocks or is slow, it delays all
-   subsequent log messages across the entire system.
+1. **Log Queue Drop Policy:** If the queue is full (64 entries pending), new log entries are dropped silently in the
+   vprintf hook. This can occur during very high log output bursts. The fast non-blocking `xQueueSend(0)` is
+   intentional — blocking inside the vprintf hook would stall all tasks that emit log messages.
 
-2. **No Log Level Filtering in Router:** All log messages are forwarded to callbacks regardless of level. Filtering must
-   be implemented in each callback if needed.
+2. **No Log Level Filtering in Router:** All log messages are forwarded when `g_active` is true. Level filtering must
+   be implemented in the subscriber if needed.
 
-3. **No Message Queuing:** If WebSocket send queue is full, log messages are dropped. No retry or buffering mechanism
-   exists.
+3. **No Message History:** No ring buffer of past messages is stored. Clients that subscribe only receive messages
+   emitted after their subscription.
 
-4. **Tag Parsing is Fragile:** Relies on consistent ESP-IDF log format. If ESP-IDF changes format, parsing may fail
-   silently (log field will contain full message as fallback).
+4. **Tag Parsing is Fragile:** Relies on the consistent ESP-IDF log format `<LEVEL> (<TS>) <TAG>: <TEXT>`. If
+   ESP-IDF changes this format, parsing may fail silently (the `log` field will contain the full raw message as
+   a fallback).
 
-5. **Maximum 1 Callback:** `MAX_LOG_CALLBACKS` is set to 1. Adding syslog or other outputs requires increasing this
-   limit. This is a simple change of the `MAX_LOG_CALLBACKS` define.
+5. **Sentinel Delivery Failure:** If the queue is full when `log_router_stop()` posts the sentinel, `logSenderTask`
+   will not exit until the next real entry creates space. The `DockApi` destructor mitigates this with a 50 ms
+   `vTaskDelay` followed by a forced `vTaskDelete`.
+
+6. **`ESP_EARLY_LOGx` / `ESP_DRAM_LOGx` Not Intercepted:** These macros bypass `esp_log_set_vprintf()` and go
+   directly to the ROM printf. Only `ESP_LOGx` macros are routed through the log router.
 
 ## Future Enhancements
 
 ### Potential Features
 
-| Feature             | Priority | Description                                 |
-|---------------------|----------|---------------------------------------------|
-| Syslog output       | Medium   | Add UDP syslog callback for network logging |
-| Log level filtering | Low      | Per-callback level filter to reduce traffic |
-| Tag filtering       | Low      | Subscribe to specific tags only             |
+| Feature             | Priority | Description                                          |
+|---------------------|----------|------------------------------------------------------|
+| Syslog output       | Medium   | Consume from same queue in a second task, UDP syslog |
+| Log level filtering | Low      | Per-subscriber level filter to reduce WS traffic     |
+| Tag filtering       | Low      | Subscribe to specific tags only                      |
+| Message history     | Low      | Ring buffer of last N entries for new subscribers    |
 
-### Potential Improvements
+### Syslog Integration Note
 
-1. **Asynchronous Queue:** Add FreeRTOS queue or a ring-buffer between log router and callbacks. Callbacks would queue
-   messages and a
-   dedicated task would process them.
-
-2. **Log Buffering:** Store last N log messages in RAM for retrieval on client connect (history on subscription).
+The queue-based architecture makes adding a syslog output straightforward. A second consumer task would call
+`log_router_start()` independently, receiving its own queue handle, and format entries as RFC 5424 PDUs sent via UDP.
+The `log_router_stop()` / sentinel lifecycle applies identically. The two consumers operate fully independently
+with no shared state beyond the router's `g_active` flag.
 
 ## References
 
 ### ESP-IDF Documentation
 
 - [Logging System](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/system/log.html)
-- `esp_log_set_vprintf()` - Override log output function
-- `esp_log_level_set()` - Set log level per tag
+- `esp_log_set_vprintf()` — Override log output function
+- `esp_log_level_set()` — Set log level per tag
 
 ### Related Components
 
-- `components/webserver/` - WebSocket server implementation
-- `main/ucd_api.cpp` - DockApi with log streaming integration
-- `main/ucd_api.h` - DockApi class declaration
+- `components/webserver/` — WebSocket server implementation
+- `main/ucd_api.cpp` — DockApi with log streaming integration
+- `main/ucd_api.h` — DockApi class declaration

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -34,6 +34,13 @@ static const int AUTH_TIMER_CHECK_PERIOD_MS = 5000;
 // Limited because of silently dropping queue work: https://github.com/espressif/esp-idf/issues/8440
 static const int MAX_WS_CLOSE_COUNT = 2;
 
+// Maximum number of WebSocket client log stream subscriptions
+static const int MAX_WS_LOG_SUBS = 2;
+// Throttle log message sending to avoid dropping WebSocket messages (or other responses).
+// Note: with default IDF CONFIG_LWIP_UDP_RECVMBOX_SIZE=6, the delay should be set to 250 ms
+// 100ms seems to be ok for IDF CONFIG_LWIP_UDP_RECVMBOX_SIZE=12
+static const int WS_LOG_DELAY_MS = 100;
+
 // Feature flag: do not send a WebSocket response for ir_send when an IR sequence is extended.
 static const int API_FEATURE_FLAG_IR_REPEAT_NO_RESPONSE = BIT0;
 // Feature flag: `ir_send` command supports the `hold` parameter to send ir command for x milliseconds.
@@ -217,16 +224,16 @@ DockApi::DockApi(Config *config, WebServer *web, port_map_t ports)
       auth_timer_(nullptr),
       serial_event_mutex_(xSemaphoreCreateMutex()),
       log_subscribers_mutex_(xSemaphoreCreateMutex()),
-      log_callback_id_(-1) {
+      log_sender_task_handle_(nullptr),
+      log_queue_(nullptr) {
     assert(config_);
     assert(web_);
     assert(unauthenticated_fds_mutex_);
     assert(serial_event_mutex_);
     assert(log_subscribers_mutex_);
 
-    // Initialize log router and register callback
+    // Initialize log router
     log_router_init();
-    log_router_register_callback(logCallback, this, &log_callback_id_);
 
     web_->onWsEvent([this](httpd_req_t *req, int sockfd, WsTypeEnum type, uint8_t *payload, size_t length,
                            bool authenticated) -> esp_err_t {
@@ -286,10 +293,16 @@ DockApi::DockApi(Config *config, WebServer *web, port_map_t ports)
                     xSemaphoreGive(serial_event_mutex_);
                 }
 
-                // Remove from log subscribers
+                // Remove from log subscribers and stop the router if no one remains.
                 if (xSemaphoreTake(log_subscribers_mutex_, pdMS_TO_TICKS(1000)) == pdTRUE) {
                     log_subscribers_.erase(sockfd);
+                    size_t remaining = log_subscribers_.size();
                     xSemaphoreGive(log_subscribers_mutex_);
+                    if (remaining == 0 && log_queue_ != nullptr) {
+                        log_router_stop();
+                        log_queue_ = nullptr;
+                        // log_sender_task_handle_ is nulled by the task itself after self-deletion
+                    }
                 }
 
                 return ESP_OK;
@@ -322,12 +335,19 @@ DockApi::~DockApi() {
 
     deinitSerialBuffers();
 
-    // Unregister log callback
-    if (log_callback_id_ >= 0) {
-        log_router_unregister_callback(log_callback_id_);
-        log_callback_id_ = -1;
+    if (log_queue_ != nullptr) {
+        log_router_stop();
+        log_queue_ = nullptr;
     }
-
+    // Give the task a moment to process the sentinel and self-delete.
+    // If it does not, force-kill — acceptable in a full teardown.
+    if (log_sender_task_handle_) {
+        vTaskDelay(pdMS_TO_TICKS(50));
+        if (log_sender_task_handle_) {  // re-check after delay
+            vTaskDelete(log_sender_task_handle_);
+            log_sender_task_handle_ = nullptr;
+        }
+    }
     vSemaphoreDelete(log_subscribers_mutex_);
 }
 
@@ -1251,39 +1271,66 @@ uint16_t DockApi::handleEnableLogEvents(int sockfd, const cJSON *root, cJSON *re
         return 400;
     }
 
-    if (xSemaphoreTake(log_subscribers_mutex_, pdMS_TO_TICKS(1000)) == pdTRUE) {
-        if (enable) {
-            log_subscribers_.insert(sockfd);
-            ESP_LOGI(TAG, "Client %d subscribed to log streaming (total: %d)", sockfd, log_subscribers_.size());
-        } else {
-            log_subscribers_.erase(sockfd);
-            ESP_LOGD(TAG, "Client %d unsubscribed from log streaming (total: %d)", sockfd, log_subscribers_.size());
-        }
-        xSemaphoreGive(log_subscribers_mutex_);
-    } else {
+    if (xSemaphoreTake(log_subscribers_mutex_, pdMS_TO_TICKS(50)) != pdTRUE) {
         ESP_LOGE(TAG, "Failed to acquire log_subscribers_mutex");
         cJSON_AddStringToObject(responseDoc, msgError, "Internal error");
         return 500;
+    }
+
+    if (enable) {
+        if (log_subscribers_.size() >= MAX_WS_LOG_SUBS) {
+            xSemaphoreGive(log_subscribers_mutex_);
+            cJSON_AddStringToObject(responseDoc, msgError, "Max subscriptions reached");
+            return 503;
+        }
+        log_subscribers_.insert(sockfd);
+        ESP_LOGI(TAG, "Client %d subscribed to log streaming (%zu/%d)", sockfd, log_subscribers_.size(),
+                 MAX_WS_LOG_SUBS);
+    } else {
+        log_subscribers_.erase(sockfd);
+        ESP_LOGD(TAG, "Client %d unsubscribed from log streaming (%zu/%d)", sockfd, log_subscribers_.size(),
+                 MAX_WS_LOG_SUBS);
+    }
+
+    size_t subscriber_count = log_subscribers_.size();
+    xSemaphoreGive(log_subscribers_mutex_);
+
+    // Start or stop the router based on whether any subscriber remains.
+    if (subscriber_count > 0 && log_queue_ == nullptr) {
+        // First subscriber: start router and create the sender task.
+        // log_router_start is idempotent; calling it again just returns the existing queue.
+        log_router_start(&log_queue_);
+        xTaskCreate(logSenderTask, "log_sender", 3072, this, tskIDLE_PRIORITY + 1, &log_sender_task_handle_);
+        assert(log_sender_task_handle_);
+    } else if (subscriber_count == 0 && log_queue_ != nullptr) {
+        log_router_stop();
+        log_queue_ = nullptr;
     }
 
     return 200;
 }
 
 void DockApi::sendLogToSubscribers(const char *tag, esp_log_level_t level, const char *message, size_t len) {
-    // best effort, we are in the logging context and should not block
-    if (xSemaphoreTake(log_subscribers_mutex_, pdMS_TO_TICKS(5)) != pdTRUE) {
+    // Snapshot subscribers under lock — fast, no I/O
+    int    fds[MAX_WS_LOG_SUBS];
+    size_t count = 0;
+    if (xSemaphoreTake(log_subscribers_mutex_, pdMS_TO_TICKS(5)) == pdTRUE) {
+        for (int fd : log_subscribers_) {
+            if (count < MAX_WS_LOG_SUBS) {
+                fds[count++] = fd;
+            }
+        }
+        xSemaphoreGive(log_subscribers_mutex_);  // release BEFORE building JSON
+    } else {
         return;
     }
-
-    if (log_subscribers_.empty()) {
-        xSemaphoreGive(log_subscribers_mutex_);
+    if (count == 0) {
         return;
     }
 
     // Build JSON log message using cJSON
     cJSON *event = cJSON_CreateObject();
     if (!event) {
-        xSemaphoreGive(log_subscribers_mutex_);
         return;
     }
 
@@ -1359,52 +1406,55 @@ void DockApi::sendLogToSubscribers(const char *tag, esp_log_level_t level, const
         msg_len = 500;
     }
 
-    // Create a null-terminated copy
-    // Note: No manual JSON escaping needed - cJSON handles this automatically
-    char *msg_copy = (char *)malloc(msg_len + 1);
-    if (!msg_copy) {
-        cJSON_Delete(event);
-        xSemaphoreGive(log_subscribers_mutex_);
-        return;
-    }
-    strncpy(msg_copy, text_start, msg_len);
-    msg_copy[msg_len] = '\0';
-
-    cJSON_AddStringToObject(event, "log", msg_copy);
-    free(msg_copy);
+    // Avoid using malloc for another copy
+    char saved = text_start[msg_len];
+    ((char *)text_start)[msg_len] = '\0';  // safe: text_start points into message
+    cJSON_AddStringToObject(event, "log", text_start);
+    ((char *)text_start)[msg_len] = saved;
 
     char *json_str = cJSON_PrintUnformatted(event);
     cJSON_Delete(event);
 
     if (!json_str) {
-        xSemaphoreGive(log_subscribers_mutex_);
         return;
     }
 
     // Send to all subscribers
-    for (int fd : log_subscribers_) {
+    for (size_t i = 0; i < count; i++) {
         // Important: needs to be const char* to avoid freeing the buffer in sendWsTxt!
-        web_->sendWsTxt(fd, (const char *)json_str);
+        web_->sendWsTxt(fds[i], (const char *)json_str);
+        // Quick and dirty message throttling: otherwise the internal httpd work queue starts dropping messages!
+        // Getting a "queue full" response from httpd_queue_work without blocking was only recently fixed in IDF:
+        // https://github.com/espressif/esp-idf/commit/c911c781ae94e40d0df6596a25c53025c5f98fb5
+        vTaskDelay(pdMS_TO_TICKS(WS_LOG_DELAY_MS));
     }
 
     cJSON_free(json_str);
-    xSemaphoreGive(log_subscribers_mutex_);
 }
 
-esp_err_t DockApi::logCallback(const char *tag, esp_log_level_t level, const char *message, size_t len, void *ctx) {
-    // Attention: This callback is called from the logging system, which may have very strict timing requirements.
-    // It should not perform any heavy processing or blocking operations. The message should be forwarded to subscribers
-    // as quickly as possible, and any complex processing (like JSON formatting) should ideally be deferred to the
-    // decoupled subscriber side if possible.
-    // For the moment we keep it simple and do the JSON formatting here, but if performance becomes an issue,
-    // we should consider a more asynchronous approach where we just forward the raw log message and metadata to a
-    // queue, and have a separate task processing the queue and sending events to subscribers. Note: sending the WS
-    // messages is already asynchronous in httpd with a work queue.
-    DockApi *that = static_cast<DockApi *>(ctx);
-    if (that) {
-        that->sendLogToSubscribers(tag, level, message, len);
+void DockApi::logSenderTask(void *arg) {
+    DockApi      *self = static_cast<DockApi *>(arg);
+    QueueHandle_t q = self->log_queue_;
+    log_entry_t  *entry = nullptr;
+
+    while (xQueueReceive(q, &entry, portMAX_DELAY) == pdTRUE && entry) {
+        if (entry->level == LOG_ENTRY_SENTINEL) {
+            free(entry);
+            break;  // clean exit
+        }
+        self->sendLogToSubscribers(entry->tag, static_cast<esp_log_level_t>(entry->level), entry->message, entry->len);
+        free(entry);
+        entry = nullptr;
     }
-    return ESP_OK;
+
+    // Drain any real entries that arrived between the sentinel and here.
+    // This is a best-effort flush before shutdown — ensures no entry leaks.
+    while (xQueueReceive(q, &entry, 0) == pdTRUE && entry) {
+        free(entry);
+    }
+
+    self->log_sender_task_handle_ = nullptr;
+    vTaskDelete(nullptr);
 }
 
 uint16_t DockApi::processGetPortModes(cJSON *responseDoc) {

--- a/main/ucd_api.h
+++ b/main/ucd_api.h
@@ -83,9 +83,9 @@ class DockApi {
     void loadSerialBufferConfig(uint8_t port);
 
     // Log streaming support
-    uint16_t         handleEnableLogEvents(int sockfd, const cJSON* root, cJSON* responseDoc);
-    void             sendLogToSubscribers(const char* tag, esp_log_level_t level, const char* message, size_t len);
-    static esp_err_t logCallback(const char* tag, esp_log_level_t level, const char* message, size_t len, void* ctx);
+    uint16_t    handleEnableLogEvents(int sockfd, const cJSON* root, cJSON* responseDoc);
+    void        sendLogToSubscribers(const char* tag, esp_log_level_t level, const char* message, size_t len);
+    static void logSenderTask(void* arg);
 
     Config*    config_;
     WebServer* web_;
@@ -106,5 +106,7 @@ class DockApi {
     // Per-client log streaming subscriptions
     std::set<int>     log_subscribers_;
     SemaphoreHandle_t log_subscribers_mutex_;
-    int               log_callback_id_;
+
+    TaskHandle_t  log_sender_task_handle_;
+    QueueHandle_t log_queue_;
 };

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -10,9 +10,6 @@ CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ=240
 
 CONFIG_ESP_TASK_WDT_PANIC=y
 
-# default 2304 causes stack overflow with REST requests. Likely caused by the stack allocated log buffer in the log router.
-CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=3072
-
 # default 2048 causes stack overflow and 3072 is still not enough. Likely because of timer usage in the state machines.
 CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=4092
 
@@ -81,6 +78,13 @@ CONFIG_UCD_GLOBALCACHE_MAX_CLIENTS=6
 CONFIG_LWIP_MAX_ACTIVE_TCP=32
 # Maximum number of simultaneously listening TCP connections (leave at default): WebSocket API, webserver, GlobalCache server
 CONFIG_LWIP_MAX_LISTENING_TCP=16
+
+#
+# UDP
+#
+# Increase from default 6 for a larger httpd work queue, otherwise response messages are silently dropped if full.
+CONFIG_LWIP_UDP_RECVMBOX_SIZE=12
+# end of UDP
 
 #
 # SNTP


### PR DESCRIPTION
Replace the synchronous log-router logic with an async queue to avoid race conditions and handle message bursts (e.g., during external port detection), which was introduced in #77.

- Replace `log_output_callback_t` / `register/unregister` API with `log_router_start()` and `log_router_stop()` backed by a FreeRTOS queue (64 entries, max log message length 100 bytes).
- `logSenderTask` created on first WS subscriber, self-deletes on sentinel receipt; zero scheduler cost during normal operation.
- Cap WS log subscribers at 2 with message send throttling due to small and slow httpd work queue that silently drops messages if full.
- Drop queue entries non-blocking on full queue.
- Revert increased `CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE`
- Double `CONFIG_LWIP_UDP_RECVMBOX_SIZE` to 12 to increase internal httpd work queue.

---

LLM disclaimer: assisted by Claude Sonnet 4.6 for the refactoring and documentation (just don't trust it for efficient FreeRTOS queue handling logic…).