### PR TITLE
fix: update UART cfg in web-ui, stop console on disconnect

### DIFF
--- a/components/external_port/external_port.cpp
+++ b/components/external_port/external_port.cpp
@@ -203,6 +203,9 @@ esp_err_t ExternalPort::changeMode(ExtPortMode mode) {
         return ESP_ERR_NOT_SUPPORTED;
     }
     if (mode == mode_) {
+        if (mode_ == RS232) {
+            return changeUartCfg();
+        }
         return ESP_OK;
     }
 
@@ -335,9 +338,7 @@ esp_err_t ExternalPort::setUartConfig(std::unique_ptr<UartConfig> config) {
     }
 
     if (mode_ == RS232) {
-        ESP_LOGW(
-            tag_,
-            "Output is already configured to RS232: new UART configuration will be applied at next initialization!");
+        ESP_LOGW(tag_, "Output is already configured to RS232: new UART cfg will be applied at next init!");
     }
 
     uart_cfg_ = std::move(config);
@@ -460,7 +461,6 @@ esp_err_t ExternalPort::initUart() {
 
     uart_config_t uart_config = uart_cfg_->toConfig();
 
-    // TODO finalize init uart with queue etc
     int event_queue_size = 16;
     int intr_alloc_flags = 0;
 
@@ -490,11 +490,19 @@ err_uart_config:
     return ret;
 }
 
-void ExternalPort::deinitUart() {
-    // TODO(zehnm) stop task & event loop
-    // vTaskDelete(uart_tsk_hdl_);
-    // esp_event_loop_delete(uear_event_loop_hdl_);
+esp_err_t ExternalPort::changeUartCfg() {
+    if (uart_cfg_ == nullptr || config_.uart_port == UART_NUM_MAX) {
+        return ESP_ERR_INVALID_STATE;
+    }
 
+    ESP_LOGI(tag_, "Setting UART cfg: %s", uart_cfg_->toString().c_str());
+    uart_config_t uart_config = uart_cfg_->toConfig();
+
+    ESP_RETURN_ON_ERROR(uart_param_config(config_.uart_port, &uart_config), tag_, "config uart parameter failed");
+    return ESP_OK;
+}
+
+void ExternalPort::deinitUart() {
     if (uart_event_queue_) {
         xQueueReset(uart_event_queue_);
         uart_event_queue_ = nullptr;

--- a/components/external_port/external_port.h
+++ b/components/external_port/external_port.h
@@ -115,6 +115,7 @@ class ExternalPort {
     void        setTx(bool high);
     esp_err_t   measureGnd(int *voltage);
     esp_err_t   initUart();
+    esp_err_t   changeUartCfg();
     void        deinitUart();
     esp_err_t   measureVcc(int *voltage);
     void        applyVector(int g, int e, int t, bool is_mono);
@@ -139,7 +140,7 @@ class ExternalPort {
     esp_timer_handle_t          trigger_timer_;
     SemaphoreHandle_t           port_lock_;
     std::shared_ptr<AdcReader>  vcc_reader_;
-    // TODO do we need an event queue?
+
     QueueHandle_t uart_event_queue_;
     bool          uart_driver_installed_;
 };

--- a/components/serial_bridge/README.md
+++ b/components/serial_bridge/README.md
@@ -371,6 +371,12 @@ Response:
   "terminator": "\r",
   "buffer_size": 512,
   "timeout_ms": 100,
+  "uart": {
+    "baud_rate": 115200,
+    "data_bits": 8,
+    "parity": "none",
+    "stop_bits": "1"
+  }
   "code": 200
 }
 ```

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -1455,6 +1455,8 @@ uint16_t DockApi::processGetSerialConfig(const cJSON *root, cJSON *responseDoc) 
     cJSON_AddNumberToObject(responseDoc, "buffer_size", pbuf.buffer_size);
     cJSON_AddNumberToObject(responseDoc, "timeout_ms", pbuf.timeout_ms);
 
+    addUartNode(port, responseDoc);
+
     return 200;
 }
 
@@ -1912,21 +1914,25 @@ void DockApi::fillPortMode(const std::shared_ptr<ExternalPort> &extPort, cJSON *
     }
 
     if (active_mode == RS232) {
-        std::string uart_cfg = config_->getExternalPortUart(port);
+        addUartNode(port, responseDoc);
+    }
+}
 
-        auto cfg = UartConfig::fromString(uart_cfg.c_str());
-        if (cfg == nullptr) {
-            cfg = UartConfig::defaultCfg();
-            ESP_LOGW(TAG, "Invalid UART configuration for port %d: '%s'. Using default", port, uart_cfg.c_str());
-        }
+void DockApi::addUartNode(uint8_t port, cJSON *responseDoc) {
+    std::string uart_cfg = config_->getExternalPortUart(port);
 
-        cJSON *uart = cJSON_AddObjectToObject(responseDoc, "uart");
-        if (uart) {
-            cJSON_AddNumberToObject(uart, "baud_rate", cfg->baud_rate);
-            cJSON_AddNumberToObject(uart, "data_bits", cfg->dataBits());
-            cJSON_AddStringToObject(uart, "parity", cfg->parityAsString());
-            cJSON_AddStringToObject(uart, "stop_bits", cfg->stopBitsAsString());
-        }
+    auto cfg = UartConfig::fromString(uart_cfg.c_str());
+    if (cfg == nullptr) {
+        cfg = UartConfig::defaultCfg();
+        ESP_LOGW(TAG, "Invalid UART configuration for port %d: '%s'. Using default", port, uart_cfg.c_str());
+    }
+
+    cJSON *uart = cJSON_AddObjectToObject(responseDoc, "uart");
+    if (uart) {
+        cJSON_AddNumberToObject(uart, "baud_rate", cfg->baud_rate);
+        cJSON_AddNumberToObject(uart, "data_bits", cfg->dataBits());
+        cJSON_AddStringToObject(uart, "parity", cfg->parityAsString());
+        cJSON_AddStringToObject(uart, "stop_bits", cfg->stopBitsAsString());
     }
 }
 
@@ -1966,7 +1972,9 @@ uint16_t DockApi::processSetPortMode(const cJSON *root) {
         if (ports_[port]->setUartConfig(std::move(uart_cfg)) != ESP_OK) {
             return 400;
         }
-        config_->setExternalPortUart(port, uart_str.c_str());
+        if (!config_->setExternalPortUart(port, uart_str.c_str())) {
+            return 500;
+        }
     }
 
     esp_err_t ret = ports_[port]->changeMode(mode);

--- a/main/ucd_api.h
+++ b/main/ucd_api.h
@@ -57,6 +57,7 @@ class DockApi {
     uint16_t processGetPortModes(cJSON* responseDoc);
     uint16_t processGetPortMode(const cJSON* root, cJSON* responseDoc);
     void     fillPortMode(const std::shared_ptr<ExternalPort>& extPort, cJSON* responseDoc);
+    void     addUartNode(uint8_t port, cJSON* responseDoc);
     uint16_t processSetPortMode(const cJSON* root);
     uint16_t processGetPortTrigger(const cJSON* root, cJSON* responseDoc);
     uint16_t processSetPortTrigger(const cJSON* root);

--- a/webroot/app.js
+++ b/webroot/app.js
@@ -374,6 +374,30 @@ const WS = {
     this.pending = {};
     this.stopStatusRefresh();
     this.stopInactivityTimer();
+    this.resetClientState();
+  },
+
+  resetClientState: function () {
+    // Reset RS232 console state for both ports
+    if (Pages.Ports) {
+      Pages.Ports.serialEnabled[1] = false;
+      Pages.Ports.serialEnabled[2] = false;
+      for (let n = 1; n <= 2; n++) {
+        const btn = document.getElementById("btn-port" + n + "-console");
+        if (btn) {
+          btn.textContent = I18N.t("btn_enable_console");
+        }
+      }
+    }
+    // Reset log streaming state
+    if (Pages.Logs) {
+      Pages.Logs.streaming = false;
+      const logBtn = document.getElementById("btn-log-stream");
+      if (logBtn) {
+        logBtn.textContent = I18N.t("btn_start_streaming");
+        logBtn.classList.remove("btn-warn");
+      }
+    }
   },
 
   on: function (msg, handler) {
@@ -1688,10 +1712,14 @@ Pages.Ports = {
   loadSerialConfig: function (port) {
     WS.request("get_serial_config", {port: port}).then(function (cfg) {
       const p = port;
-      if (cfg.baud_rate !== undefined) document.getElementById("port" + p + "-baud").value = cfg.baud_rate;
-      if (cfg.data_bits !== undefined) document.getElementById("port" + p + "-databits").value = cfg.data_bits;
-      if (cfg.stop_bits !== undefined) document.getElementById("port" + p + "-stopbits").value = cfg.stop_bits;
-      if (cfg.parity) document.getElementById("port" + p + "-parity").value = cfg.parity;
+      const uart = cfg.uart;
+      if (uart) {
+        if (uart.baud_rate !== undefined) document.getElementById("port" + p + "-baud").value = uart.baud_rate;
+        if (uart.data_bits !== undefined) document.getElementById("port" + p + "-databits").value = uart.data_bits;
+        if (uart.stop_bits !== undefined) document.getElementById("port" + p + "-stopbits").value = uart.stop_bits;
+        if (uart.parity) document.getElementById("port" + p + "-parity").value = uart.parity;
+      }
+
       if (cfg.buffering) document.getElementById("port" + p + "-buffering").value = cfg.buffering;
       if (cfg.terminator !== undefined) {
         document.getElementById("port" + p + "-terminator").value = Pages.Ports.charToHex(cfg.terminator);


### PR DESCRIPTION
- Show correct UART configuration in management web-UI.
- Allow changing UART configuration without restart.
- Stop RS232 consoles on disconnect.
- Stop log console on disconnect.