### PR TITLE
feat: add RAW IR-Learning support

### DIFF
--- a/components/infrared/ir_codes.h
+++ b/components/infrared/ir_codes.h
@@ -20,6 +20,7 @@ enum class IRFormat {
     UNFOLDED_CIRCLE = 1,
     PRONTO = 2,
     GLOBAL_CACHE = 3,
+    RAW = 4,
 };
 
 struct GpioPinMask {

--- a/components/infrared/service_ir.cpp
+++ b/components/infrared/service_ir.cpp
@@ -29,9 +29,13 @@ const char *irLog = "IR";
 const char *irLogSend = "IRSEND";
 const char *irLogLearn = "IRLEARN";
 
+/// Learning is active
 const int IR_LEARNING_BIT = BIT0;
-const int IR_REPEAT_BIT = BIT1;
-const int IR_REPEAT_STOP_BIT = BIT2;
+/// Return raw timings for IR learning (requires IR_LEARNING_BIT)
+const int IR_LEARNING_RAW_BIT = BIT1;
+/// Repeat active IR command
+const int IR_REPEAT_BIT = BIT2;
+const int IR_REPEAT_STOP_BIT = BIT3;
 
 /// Limit maximum repeat count in continuous IR repeat mode to 20.
 const uint32_t MAX_REPEAT = 20;
@@ -114,17 +118,22 @@ void InfraredService::setIrLearnPriority(uint16_t priority) {
     }
 }
 
-void InfraredService::startIrLearn() {
+void InfraredService::startIrLearn(IRFormat irFormat) {
     // Note: UC_EVENT_IR_LEARNING_START event is sent when the learning loop starts
     if (m_eventgroup) {
-        xEventGroupSetBits(m_eventgroup, IR_LEARNING_BIT);
+        EventBits_t uxBitsToSet = IR_LEARNING_BIT;
+        if (irFormat == IRFormat::RAW) {
+            uxBitsToSet |= IR_LEARNING_RAW_BIT;
+        }
+
+        xEventGroupSetBits(m_eventgroup, uxBitsToSet);
     }
 }
 
 void InfraredService::stopIrLearn() {
     // Note: UC_EVENT_IR_LEARNING_STOP event is sent after the learning loop stops
     if (m_eventgroup) {
-        xEventGroupClearBits(m_eventgroup, IR_LEARNING_BIT);
+        xEventGroupClearBits(m_eventgroup, IR_LEARNING_BIT | IR_LEARNING_RAW_BIT);
     }
 }
 
@@ -602,6 +611,44 @@ void InfraredService::send_ir_f(void *param) {
     }
 }
 
+/// Optimized RAW serialization using string formatting instead of inefficient cJSON array handling
+static char *serialize_raw_optimized(const decode_results *results, const char *code) {
+    uint16_t count = results->rawlen - 1;
+
+    // Worst case per entry: 5 digits + comma = 6 chars. Plus envelope.
+    size_t buf_size = count * 6 + 128;
+    char  *buf = reinterpret_cast<char *>(malloc(buf_size));
+    if (buf == NULL) {
+        ESP_LOGE(irLogLearn, "Not enough memory for RAW IR learning");
+        return NULL;
+    }
+
+    int offset = snprintf(buf, buf_size,
+                          "{\"type\":\"event\",\"msg\":\"ir_receive\",\"format\":\"hex\",\"ir_code\":\"%s\","
+                          "\"overflow\":%s,\"raw\":[",
+                          code, results->overflow ? "true" : "false");
+
+    for (uint16_t i = 0; i < count; i++) {
+        uint16_t src_idx = i + 1;  // skip index 0
+        int32_t  us = static_cast<int32_t>(results->rawbuf[src_idx]) * kRawTick;
+
+        int written =
+            snprintf(buf + offset, buf_size - offset, i < count - 1 ? "%ld," : "%ld", (src_idx % 2 == 1) ? us : -us);
+        if (written < 0 || (size_t)written >= buf_size - offset) {
+            if (written > 0) {
+                offset += written;
+            }
+            break;
+        }
+        offset += written;
+    }
+
+    if (offset < buf_size) {
+        snprintf(buf + offset, buf_size - offset, "]}");
+    }
+    return buf;
+}
+
 void InfraredService::learn_ir_f(void *param) {
     if (param == nullptr) {
         ESP_LOGE(irLogLearn, "BUG: missing learn_ir_f param");
@@ -633,9 +680,13 @@ void InfraredService::learn_ir_f(void *param) {
             continue;
         }
 
+        bool raw_mode = bits & IR_LEARNING_RAW_BIT;
+
         ESP_LOGI(irLogLearn, "ir_learn task starting");
-        ESP_ERROR_CHECK_WITHOUT_ABORT(
-            esp_event_post(UC_DOCK_EVENTS, UC_EVENT_IR_LEARNING_START, NULL, 0, pdMS_TO_TICKS(500)));
+        uc_event_ir_start_t ir_start;
+        ir_start.irFormat = static_cast<int8_t>(raw_mode ? IRFormat::RAW : IRFormat::UNFOLDED_CIRCLE);
+        ESP_ERROR_CHECK_WITHOUT_ABORT(esp_event_post(UC_DOCK_EVENTS, UC_EVENT_IR_LEARNING_START, &ir_start,
+                                                     sizeof(ir_start), pdMS_TO_TICKS(500)));
 
         // enable IR learning
         irrecv.enableIRIn();
@@ -654,6 +705,7 @@ void InfraredService::learn_ir_f(void *param) {
                 continue;
             }
 
+            std::string   code;
             bool          failed = false;
             uc_event_ir_t event_ir;
             memset(&event_ir, 0, sizeof(event_ir));
@@ -675,46 +727,56 @@ void InfraredService::learn_ir_f(void *param) {
             if (failed) {
                 ESP_ERROR_CHECK_WITHOUT_ABORT(esp_event_post(UC_DOCK_EVENTS, UC_EVENT_IR_LEARNING_FAIL, &event_ir,
                                                              sizeof(event_ir), pdMS_TO_TICKS(500)));
-                continue;
+                if (!raw_mode) {
+                    continue;
+                }
+                // empty code indicates a failed learned code in raw mode
+                code = "";
+            } else {
+                code += std::to_string(results.decode_type);
+                code += ";";
+                code += resultToHexidecimal(&results);
+                code += ";";
+                code += std::to_string(results.bits);
+                code += ";";
+                // TODO(#30) adjust repeat count for known protocols, e.g. set Sony to 2?
+                code += std::to_string(results.repeat);
+
+                // TODO(#32) here we could add "protocol specific quirk handling":
+                //           e.g. filter out double Denon codes (within 200ms) and report repeat count 2 instead
+
+                ESP_LOGI(irLogLearn, "Learned: %s", code.c_str());
+                event_ir.decode_type = results.decode_type;
+                event_ir.value = results.value;
+                event_ir.address = results.address;
+                event_ir.command = results.command;
+                ESP_ERROR_CHECK_WITHOUT_ABORT(esp_event_post(UC_DOCK_EVENTS, UC_EVENT_IR_LEARNING_OK, &event_ir,
+                                                             sizeof(event_ir), pdMS_TO_TICKS(500)));
             }
-
-            std::string code;
-            code += std::to_string(results.decode_type);
-            code += ";";
-            code += resultToHexidecimal(&results);
-            code += ";";
-            code += std::to_string(results.bits);
-            code += ";";
-            // TODO(#30) adjust repeat count for known protocols, e.g. set Sony to 2?
-            code += std::to_string(results.repeat);
-
-            // code += ";";
-            // code += std::to_string(results.address);
-            // code += ";";
-            // code += std::to_string(results.command);
-
-            // TODO(#32) here we could add "protocol specific quirk handling":
-            //           e.g. filter out double Denon codes (within 200ms) and report repeat count 2 instead
-
-            ESP_LOGI(irLogLearn, "Learned: %s", code.c_str());
-            event_ir.decode_type = results.decode_type;
-            event_ir.value = results.value;
-            event_ir.address = results.address;
-            event_ir.command = results.command;
-            ESP_ERROR_CHECK_WITHOUT_ABORT(esp_event_post(UC_DOCK_EVENTS, UC_EVENT_IR_LEARNING_OK, &event_ir,
-                                                         sizeof(event_ir), pdMS_TO_TICKS(500)));
-
-            cJSON *responseDoc = cJSON_CreateObject();
-            cJSON_AddStringToObject(responseDoc, "type", "event");
-            cJSON_AddStringToObject(responseDoc, "msg", "ir_receive");
-            cJSON_AddStringToObject(responseDoc, "ir_code", code.c_str());
 
             struct IrResponse *response = new IrResponse();
             response->clientId = -1;  // broadcast
-            char *resp = cJSON_PrintUnformatted(responseDoc);
-            response->message = resp;
-            cJSON_free(resp);
-            cJSON_Delete(responseDoc);
+
+            if (raw_mode) {
+                char *resp = serialize_raw_optimized(&results, code.c_str());
+                if (resp == NULL) {
+                    delete response;
+                    continue;
+                }
+                response->message = resp;
+                free(resp);
+            } else {
+                cJSON *responseDoc = cJSON_CreateObject();
+                cJSON_AddStringToObject(responseDoc, "type", "event");
+                cJSON_AddStringToObject(responseDoc, "msg", "ir_receive");
+                cJSON_AddStringToObject(responseDoc, "format", "hex");
+                cJSON_AddStringToObject(responseDoc, "ir_code", code.c_str());
+
+                char *resp = cJSON_PrintUnformatted(responseDoc);
+                response->message = resp;
+                cJSON_free(resp);
+                cJSON_Delete(responseDoc);
+            }
 
             if (ir->m_responseCallback) {
                 ir->m_responseCallback(response);

--- a/components/infrared/service_ir.h
+++ b/components/infrared/service_ir.h
@@ -68,7 +68,7 @@ class InfraredService {
 
     void stopSend();
 
-    void startIrLearn();
+    void startIrLearn(IRFormat irFormat = IRFormat::UNFOLDED_CIRCLE);
     void stopIrLearn();
     bool isIrLearning();
 

--- a/components/preferences/uc_events.h
+++ b/components/preferences/uc_events.h
@@ -114,6 +114,12 @@ typedef struct {
     esp_ip_addr_t ip;
 } uc_event_network_state_t;
 
+/// @brief Event structure for UC_EVENT_IR_LEARNING_START
+typedef struct {
+    /// IR format, corresponds to `IRFormat` enum
+    uint8_t irFormat;
+} uc_event_ir_start_t;
+
 typedef struct {
     /// UC error code
     uc_errors_t error;

--- a/doc/web-management-ui.md
+++ b/doc/web-management-ui.md
@@ -123,17 +123,16 @@ This might be changed if more pages are added.
 
 ## Pages
 
-| Page    | Auth Required | Description                                                                     |
-|---------|:-------------:|---------------------------------------------------------------------------------|
-| Status  |      No       | Read-only device info from `get_sysinfo`, auto-refresh every 60s (if logged in) |
-| General |      Yes      | Device name, LED brightness, access token, system actions                       |
-| Network |      Yes      | WiFi SSID/password configuration, connection status                             |
-| IR      |      Yes      | Send IR codes, IR learning with live output, IR repeat mode with hold-to-repeat |
-| Ports   |      Yes      | External port mode config, trigger control, RS232 console                       |
-| Logs    |      Yes      | Real-time log streaming with level filtering                                    |
-| OTA     |      Yes      | Firmware upload with progress                                                   |
-| Expert  |      Yes      | Experimental features (iTach emulation, AMXB beacon, RS232 TCP)                 |
-
+| Page    | Auth Required | Description                                                                                           |
+|---------|:-------------:|-------------------------------------------------------------------------------------------------------|
+| Status  |      No       | Read-only device info from `get_sysinfo`, auto-refresh every 60s (if logged in)                       |
+| General |      Yes      | Device name, LED brightness, access token, system actions                                             |
+| Network |      Yes      | WiFi SSID/password configuration, connection status                                                   |
+| IR      |      Yes      | Send IR codes, IR learning with live output, IR repeat mode with hold-to-repeat, RAW IR learning mode |
+| Ports   |      Yes      | External port mode config, trigger control, RS232 console                                             |
+| Logs    |      Yes      | Real-time log streaming with level filtering                                                          |
+| OTA     |      Yes      | Firmware upload with progress                                                                         |
+| Expert  |      Yes      | Experimental features (iTach emulation, AMXB beacon, RS232 TCP)                                       |
 
 ## WebSocket Communication
 
@@ -517,13 +516,20 @@ Native HTML Popover API for contextual help (no JavaScript required):
 - **Output Selection**: Internal (side), Port 1, Port 2 – checkboxes disabled based on actual port mode (`get_port_modes`)
 - **Repeat & Hold**: Configurable repeat count (0–20) and hold duration (ms)
 - **IR Repeat Mode**:
-  - Fieldset with "Active" checkbox and periodic interval input (100–1000 ms, default 300 ms)
-  - **Hold-to-repeat interaction**: Press and hold the Send button to continuously send IR codes
-  - Releases button sends `ir_stop` to dock
-  - Uses `f: 1` feature flag to suppress ack responses during periodic sending
-  - Auto-sets repeat count to 6 when enabling repeat mode with value 0
-  - Disabled during IR learning mode
+    - Fieldset with "Active" checkbox and periodic interval input (100–1000 ms, default 300 ms)
+    - **Hold-to-repeat interaction**: Press and hold the Send button to continuously send IR codes
+    - Releases button sends `ir_stop` to dock
+    - Uses `f: 1` feature flag to suppress ack responses during periodic sending
+    - Auto-sets repeat count to 6 when enabling repeat mode with value 0
+    - Disabled during IR learning mode
 - **Learn Mode**: Toggle button, events via `ir_receive`, displayed in console area
+- **RAW IR Learning Mode**:
+    - Checkbox to enable RAW timing capture (only available when learning is stopped)
+    - Raw output panel shows last received IR timing values (space-separated, 6-character field width)
+    - Panel is hidden when RAW mode is disabled
+    - Copy button copies raw timings to clipboard (clean format, single spaces)
+    - Overflow warning displayed if IR signal exceeds receive buffer
+    - Panel height: 10 lines default, vertically resizable
 - **Navigation Cleanup**: Active repeat transmission stops when navigating away from IR page
 - `int_top` field always sent as `false` (deprecated, not removed from API)
 
@@ -556,6 +562,41 @@ control.
 - State reset on error: timer cleared, `repeating` flag set to false, button visual updated
 - Navigation cleanup: `UI.showPage()` overridden to stop repeat when leaving IR page
 - Learning mode blocks repeat: Send button disabled when `ir_learning: true`
+
+### RAW IR Learning Mode
+
+The RAW IR learning mode captures and displays the raw IR timing values in addition to the decoded IR code.
+This is useful for advanced users, debugging, and compatibility with IR analysis tools.
+
+**UI Components:**
+
+- **RAW Mode Checkbox**: Enables/disables RAW timing capture (disabled during active learning)
+- **Raw Output Panel**: Displays last received raw timings only (does not append like decoded codes)
+    - 6-character field width per value (right-aligned)
+    - Automatic line wrapping based on container width
+    - 10 lines default height, vertically resizable
+- **Copy Button**: Copies raw timings to clipboard in clean format (single space-separated)
+- **Overflow Warning**: Shows when IR signal exceeds receive buffer capacity of the Dock
+
+**Multi-Client Support:**
+
+When another client enables RAW learning mode, the `ir_receive_on` event includes the `raw: true` field.
+The web app updates the RAW mode checkbox and shows the raw panel accordingly (also if the `ir_receive` event includes
+the `raw` field array).
+
+**Clipboard Format:**
+
+Copied raw timings use clean single-space separation for compatibility with IR analysis tools:
+```
+3344 -1704 388 -448 388 -448 388 -1286 388 -450 390 -1284
+```
+**Display Format:**
+
+UI display uses 6-character field width with non-breaking spaces for proper alignment and line wrapping:
+```
+  3344  -1704    388   -448    388   -448    388  -1286
+   388   -450    390  -1284    388   -448    388  -1286
+```
 
 ### Expert Page
 

--- a/doc/websocket-api.md
+++ b/doc/websocket-api.md
@@ -113,6 +113,45 @@ Example request from the Core-API to send a Sony TV volume up command for 2 seco
   - The repeat count in `code` is ignored.
   - The protocol specific minimal repeat count is still being used. For example Sony (protocol 4), uses a minimal repeat count of 2.
 
+### RAW IR-Learning
+
+Request:
+```json
+{
+  "type": "dock",
+  "command": "ir_receive_on",
+  "raw": true
+}
+```
+
+- `"raw": true` enables returning the RAW timings. 
+
+Event message after IR learning is enabled:
+```json
+{
+  "type": "event",
+  "msg": "ir_receive_on",
+  "raw": true
+}
+```
+
+Example response:
+```json
+{
+    "type": "event",
+    "msg": "ir_receive",
+    "format": "hex",
+    "ir_code": "4;0xA10;12;0",
+    "overflow": false,
+    "raw": [3344,-1704,388,-448,388,-448,388,-1286,388,-450,390,-1284,388,-448,388,-1286,388,-450,386,-448,388,-1286,388,-448,388,-448,388,-1286,388,-1286,388,-448,388,-448,388,-448,388,-448,388,-448,388,-448,388,-1286,388,-448,388,-1286,388,-448,388,-1286,388,-448,388,-448,388,-448,388,-1286,388,-448,388,-1286,388,-448,388,-1286,388,-448,388,-448,388,-448,388,-448,388,-448,388,-1286,388,-448,388,-448,388,-448,388,-448,388,-456,380,-448,388,-448,388,-1286,388,-448,388]
+}
+```
+
+- `format` is set to the format of the `ir_code` value, similar as in the `ir_send` message. Only `hex` for now. 
+- `ir_code` is empty if the IR code could not be decoded.
+- `overflow` is set to `true` if the IR signal was too long and didn't fit into the receive buffer.
+- `raw`: optional Mark / Space values in microseconds, if requsted in `ir_receive_on`.
+
 ### External Port Operation Mode
 
 Get operation mode:

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -846,7 +846,9 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         sockfdSendIR_ = -1;
         code = 200;
     } else if (command == "ir_receive_on") {
-        InfraredService::getInstance().startIrLearn();
+        IRFormat irFormat = cjson_get_bool(root, "raw") ? IRFormat::RAW : IRFormat::UNFOLDED_CIRCLE;
+
+        InfraredService::getInstance().startIrLearn(irFormat);
         ESP_LOGD(TAG, "IR Receive on");
     } else if (command == "ir_receive_off") {
         InfraredService::getInstance().stopIrLearn();
@@ -2061,7 +2063,11 @@ void DockApi::dockEventHandler(void *arg, esp_event_base_t event_base, int32_t e
 
     switch (event_id) {
         case UC_EVENT_IR_LEARNING_START: {
-            std::string msg = "{\"type\":\"event\",\"msg\":\"ir_receive_on\"}";
+            uc_event_ir_start_t *start = static_cast<uc_event_ir_start_t *>(event_data);
+            bool                 raw = start && start->irFormat == static_cast<uint8_t>(IRFormat::RAW);
+
+            std::string msg = "{\"type\":\"event\",\"msg\":\"ir_receive_on\"";
+            msg += raw ? ",\"raw\":true}" : "}";
             that->web_->broadcastWsTxt(msg);
             break;
         }

--- a/webroot/app.css
+++ b/webroot/app.css
@@ -586,6 +586,14 @@ button:disabled {
   color: var(--console-text);
 }
 
+#ir-raw-output {
+  white-space: pre-wrap;
+}
+
+#ir-raw-panel .console {
+  height: calc(10 * 1.4em + 16px);
+}
+
 .console-send {
   display: flex;
   gap: 8px;

--- a/webroot/app.js
+++ b/webroot/app.js
@@ -1180,6 +1180,7 @@ Pages.Network = {
   }
 };
 
+
 // ============================================================
 // Page: IR
 // ============================================================
@@ -1190,6 +1191,8 @@ Pages.IR = {
   portModes: {1: null, 2: null},
   _mouseDown: false,
   _savedHoldValue: "0",
+  rawMode: false,
+  overflowWarning: false,
 
   load: function () {
     const self = this;
@@ -1234,10 +1237,26 @@ Pages.IR = {
     document.getElementById("ir-ext2-label").classList.toggle("disabled", !port2IsIr);
   },
 
+
   updateLearnButton: function () {
     const btn = document.getElementById("btn-ir-learn");
     btn.textContent = this.learning ? I18N.t("btn_stop_learning") : I18N.t("btn_start_learning");
     btn.classList.toggle("btn-warn", this.learning);
+    // Disable raw mode checkbox when learning is active
+    const rawCheckbox = document.getElementById("ir-raw-mode");
+    rawCheckbox.disabled = this.learning;
+  },
+
+  updateRawPanelVisibility: function () {
+    const rawPanel = document.getElementById("ir-raw-panel");
+    const rawCheckbox = document.getElementById("ir-raw-mode");
+    rawPanel.classList.toggle("hidden", !rawCheckbox.checked);
+  },
+
+  updateOverflowWarning: function (overflow) {
+    const warning = document.getElementById("ir-overflow-warning");
+    this.overflowWarning = overflow === true;
+    warning.classList.toggle("hidden", !this.overflowWarning);
   },
 
   updateSendButtonState: function () {
@@ -1476,6 +1495,7 @@ Pages.IR = {
     // In normal mode, single click sends once (handled by click event)
   },
 
+
   handleSendButtonUp: function (e) {
     e.preventDefault();
     this._mouseDown = false;
@@ -1488,6 +1508,58 @@ Pages.IR = {
     if (repeatMode) {
       this.stopRepeat();
     }
+  },
+
+  copyRawToClipboard: function () {
+    const self = this;
+    const output = document.getElementById("ir-raw-output");
+    if (!output || !output.textContent) {
+      Toast.show(I18N.t("e_no_content"), true);
+      return;
+    }
+
+    // Replace non-breaking spaces with regular spaces, collapse multiple spaces, trim
+    const text = output.textContent
+      .replace(/\u00A0/g, " ")
+      .replace(/  +/g, " ")
+      .trim();
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () {
+        Toast.success(I18N.t("t_copied"));
+      }).catch(function () {
+        self.fallbackCopy(text);
+      });
+    } else {
+      this.fallbackCopy(text);
+    }
+  },
+
+  fallbackCopy: function (text) {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      document.execCommand("copy");
+      Toast.success(I18N.t("t_copied"));
+    } catch (err) {
+      Toast.error(err);
+    }
+    document.body.removeChild(textarea);
+  },
+
+  formatRawTimings: function (rawArray) {
+    const minFieldWidth = 6;
+    const nbsp = "\u00A0"; // Non-breaking space
+    const paddedValues = rawArray.map(function (value) {
+      const str = String(value);
+      const padding = minFieldWidth - str.length;
+      return nbsp.repeat(padding) + str;
+    });
+    return paddedValues.join(" ");
   },
 
   init: function () {
@@ -1506,6 +1578,17 @@ Pages.IR = {
     // Repeat mode checkbox toggle - set repeat count if 0, disable hold time
     document.getElementById("ir-repeat-mode").addEventListener("change", function () {
       self.toggleRepeatModeFields();
+    });
+
+    // RAW mode checkbox toggle
+    document.getElementById("ir-raw-mode").addEventListener("change", function () {
+      self.rawMode = this.checked;
+      self.updateRawPanelVisibility();
+    });
+
+    // Copy raw button
+    document.getElementById("btn-ir-raw-copy").addEventListener("click", function () {
+      self.copyRawToClipboard();
     });
 
     // Send button - mouse events for desktop
@@ -1548,7 +1631,12 @@ Pages.IR = {
     // Learn IR toggle
     document.getElementById("btn-ir-learn").addEventListener("click", function () {
       const command = self.learning ? "ir_receive_off" : "ir_receive_on";
-      WS.request(command).then(function () {
+      const data = {};
+      // Only send format: "raw" when enabling learning AND raw mode is checked
+      if (!self.learning && self.rawMode) {
+        data.raw = true;
+      }
+      WS.request(command, data).then(function () {
         self.learning = !self.learning;
         self.updateLearnButton();
         self.updateSendButtonState();
@@ -1561,16 +1649,30 @@ Pages.IR = {
     // Clear learned codes
     document.getElementById("btn-ir-clear").addEventListener("click", function () {
       document.getElementById("ir-learn-output").textContent = "";
+      document.getElementById("ir-raw-output").textContent = "";
+      self.updateOverflowWarning(false);
     });
 
     // Listen for ir_receive events
     WS.on("ir_receive", function (msg) {
       const output = document.getElementById("ir-learn-output");
+      const rawOutput = document.getElementById("ir-raw-output");
       if (!output) return;
       if (output.textContent) output.textContent += "\n";
       output.textContent += msg.ir_code;
       const container = output.parentElement;
       container.scrollTop = container.scrollHeight;
+
+      // Handle raw timings if present
+      if (rawOutput && msg.raw && msg.raw.length > 0) {
+        self.rawMode = true;
+        document.getElementById("ir-raw-mode").checked = self.rawMode;
+        self.updateRawPanelVisibility();
+        rawOutput.textContent = Pages.IR.formatRawTimings(msg.raw);
+      }
+
+      // Handle overflow warning
+      Pages.IR.updateOverflowWarning(msg.overflow);
     });
 
     // Listen for ir_receive_on/off events (Dock 3)
@@ -1578,6 +1680,13 @@ Pages.IR = {
       self.learning = true;
       self.updateLearnButton();
       self.updateSendButtonState();
+      // Check if raw mode was enabled (possibly by another client)
+      if (msg.raw === true) {
+        const rawCheckbox = document.getElementById("ir-raw-mode");
+        rawCheckbox.checked = true;
+        self.rawMode = true;
+        self.updateRawPanelVisibility();
+      }
     });
 
     WS.on("ir_receive_off", function (msg) {
@@ -1595,7 +1704,6 @@ Pages.IR = {
     });
   }
 };
-
 
 // ============================================================
 // Page: Ports

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -309,14 +309,32 @@
           <div id="ir-learn-info" class="info-popover" popover role="dialog">
             <p data-i18n="info_ir_learn_text">The infrared receiver is at the top of the dock.</p>
             <p><a href="https://support.unfoldedcircle.com/hc/en-us/articles/24808755980188" target="_blank" data-i18n="info_ir_protocols">Supported infrared protocols</a></p>
+            <p data-i18n="info_ir_learn_raw">RAW mode returns the timing values in microseconds, alternating between Mark (IR on, positive number) and Space (IR off, negative number).</p>
+            <p><a href="https://github.com/bengtmartensson/IrScrutinizer" target="_blank" data-i18n="info_irscrutinizer">Compatible with IrScrutinizer</a></p>
+          </div>
+          <div class="form-row">
+            <label class="cb-label">
+              <input type="checkbox" id="ir-raw-mode">
+              <span data-i18n="lbl_raw_mode">Enable RAW mode</span>
+            </label>
           </div>
           <div class="btn-group">
             <button id="btn-ir-learn" data-i18n="btn_start_learning">Start Learning</button>
             <button id="btn-ir-clear" data-i18n="btn_clear">Clear</button>
           </div>
-          <div class="console">
+          <div class="console console-resize">
             <pre id="ir-learn-output"></pre>
           </div>
+          <div id="ir-raw-panel" class="hidden">
+            <h3 data-i18n="hdr_raw_timings">Raw Timings</h3>
+            <div class="console console-resize">
+              <pre id="ir-raw-output"></pre>
+            </div>
+            <div class="form-row">
+              <button id="btn-ir-raw-copy" data-i18n="btn_copy">Copy</button>
+            </div>
+          </div>
+          <div id="ir-overflow-warning" class="note note-warning hidden" data-i18n="lbl_raw_overflow">Data overflow, IR signal too long</div>
         </div>
       </section>
 

--- a/webroot/lang/da.json
+++ b/webroot/lang/da.json
@@ -55,6 +55,8 @@
   "lbl_ir_active": "Aktiv",
   "lbl_mode": "Tilstand",
   "lbl_active": "Aktiv:",
+  "lbl_raw_mode": "Aktivér RAW-tilstand",
+  "lbl_raw_overflow": "Dataoverløb, IR-signal for langt",
   "lbl_baud_rate": "Baud-hastighed",
   "lbl_data_bits": "Databits",
   "lbl_stop_bits": "Stopbits",
@@ -116,6 +118,7 @@
   "btn_resume": "Fortsæt",
   "btn_start_streaming": "Start streaming",
   "btn_stop_streaming": "Stop streaming",
+  "btn_copy": "Kopiér",
 
   "info_net_cfg_ipv4": "Kun IPv4 understøttes til statisk netværkskonfiguration.",
   "info_net_cfg_restart": "Docken genstarter efter anvendelse af netværksændringer.",
@@ -127,6 +130,8 @@
   "info_ir_interval": "Interval i ms til gentaget udsendelse af IR-koden, mens sendeknappen holdes nede.",
   "info_ir_learn_text": "Infrarød-modtageren er placeret øverst på dock'en.",
   "info_ir_protocols": "Understøttede infrarøde protokoller",
+  "info_ir_learn_raw": "RAW-tilstand returnerer timing-værdier i mikrosekunder, skiftevis mellem Mark (IR tændt, positivt tal) og Space (IR slukket, negativt tal).",
+  "info_irscrutinizer": "Kompatibel med IrScrutinizer",
   "info_port_active": "Registreret perifert udstyr i AUTO-tilstand.",
   "info_port_location": "Set bagfra, venstre mod højre: Ethernet — <strong>Port 1</strong> — <strong>Port 2</strong> — USB-C.",
   "info_port_pinout": "3.5 mm jack pinout",
@@ -165,6 +170,7 @@
   "t_ir_sent": "IR-kode sendt",
   "t_ir_learn_on": "IR-læring startet",
   "t_ir_learn_off": "IR-læring stoppet",
+  "t_copied": "Kopieret til udklipsholder",
   "t_port_mode": "Port {port} tilstand sat til {mode}",
   "t_uart_applied": "UART-konfiguration anvendt",
   "t_buffering_applied": "Buffering-konfiguration anvendt",
@@ -198,5 +204,6 @@
   "e_upload_auth": "Upload-godkendelse mislykkedes",
   "e_conn_lost": "Forbindelse mistet",
   "e_upload_failed": "Upload mislykkedes: {status}",
-  "e_invalid_ip": "Ugyldigt IPv4-adresseformat"
+  "e_invalid_ip": "Ugyldigt IPv4-adresseformat",
+  "e_no_content": "Intet indhold at kopiere"
 }

--- a/webroot/lang/de.json
+++ b/webroot/lang/de.json
@@ -54,6 +54,8 @@
   "lbl_ir_active": "Aktiv",
   "lbl_mode": "Modus",
   "lbl_active": "Aktiv:",
+  "lbl_raw_mode": "RAW-Modus aktivieren",
+  "lbl_raw_overflow": "Datenüberlauf, IR-Signal zu lang",
   "lbl_baud_rate": "Baudrate",
   "lbl_data_bits": "Datenbits",
   "lbl_stop_bits": "Stoppbits",
@@ -115,6 +117,7 @@
   "btn_resume": "Fortsetzen",
   "btn_start_streaming": "Streaming starten",
   "btn_stop_streaming": "Streaming stoppen",
+  "btn_copy": "Kopieren",
 
   "info_net_cfg_ipv4": "Nur IPv4 wird für die statische Netzwerkkonfiguration unterstützt.",
   "info_net_cfg_restart": "Das Dock wird nach der Übernahme der Netzwerkänderungen neu gestartet.",
@@ -126,6 +129,8 @@
   "info_ir_interval": "Intervall in ms zum wiederholten Senden des IR-Codes, während die Sendetaste gedrückt gehalten wird.",
   "info_ir_learn_text": "Der Infrarot-Empfänger befindet sich oben am Dock.",
   "info_ir_protocols": "Unterstützte Infrarot-Protokolle",
+  "info_ir_learn_raw": "Der RAW-Modus gibt die Timing-Werte in Mikrosekunden zurück, abwechselnd Mark (IR an, positive Zahl) und Space (IR aus, negative Zahl).",
+  "info_irscrutinizer": "Kompatibel mit IrScrutinizer",
   "info_port_active": "Erkanntes Peripheriegerät im AUTO-Modus.",
   "info_port_location": "Von hinten, links nach rechts: Ethernet — <strong>Port 1</strong> — <strong>Port 2</strong> — USB-C.",
   "info_port_pinout": "Pinbelegung des 3.5-mm-Klinkensteckers",
@@ -164,6 +169,7 @@
   "t_ir_sent": "IR-Code gesendet",
   "t_ir_learn_on": "IR-Lernen gestartet",
   "t_ir_learn_off": "IR-Lernen gestoppt",
+  "t_copied": "In Zwischenablage kopiert",
   "t_port_mode": "Anschluss {port} auf {mode} gesetzt",
   "t_uart_applied": "UART-Konfiguration übernommen",
   "t_buffering_applied": "Puffer-Konfiguration übernommen",
@@ -197,5 +203,6 @@
   "e_upload_auth": "Upload-Authentifizierung fehlgeschlagen",
   "e_conn_lost": "Verbindung verloren",
   "e_upload_failed": "Upload fehlgeschlagen: {status}",
-  "e_invalid_ip": "Ungültiges IPv4-Adressformat"
+  "e_invalid_ip": "Ungültiges IPv4-Adressformat",
+  "e_no_content": "Kein Inhalt zum Kopieren"
 }

--- a/webroot/lang/en.json
+++ b/webroot/lang/en.json
@@ -19,6 +19,7 @@
   "hdr_wifi_config": "WiFi Configuration",
   "hdr_send_ir": "Send IR",
   "hdr_learn_ir": "Learn IR",
+  "hdr_raw_timings": "Raw Timings",
   "hdr_ext_port": "External Port",
   "hdr_trigger": "Trigger Control",
   "hdr_uart": "UART Configuration",
@@ -53,6 +54,8 @@
   "lbl_interval": "Interval (ms)",
   "lbl_ir_repeat_mode": "IR repeat",
   "lbl_ir_active": "Active",
+  "lbl_raw_mode": "Enable RAW mode",
+  "lbl_raw_overflow": "Data overflow, IR signal too long",
   "lbl_mode": "Mode",
   "lbl_active": "Active:",
   "lbl_baud_rate": "Baud Rate",
@@ -116,6 +119,7 @@
   "btn_resume": "Resume",
   "btn_start_streaming": "Start Streaming",
   "btn_stop_streaming": "Stop Streaming",
+  "btn_copy": "Copy",
 
   "info_net_cfg_ipv4": "Only IPv4 is supported for static network configuration.",
   "info_net_cfg_restart": "The dock will restart after applying network changes.",
@@ -127,6 +131,8 @@
   "info_ir_interval": "Interval in ms to repeatedly send the IR code while the Send button is held.",
   "info_ir_learn_text": "The infrared receiver is at the top of the dock.",
   "info_ir_protocols": "Supported infrared protocols",
+  "info_ir_learn_raw": "RAW mode returns the timing values in microseconds, alternating between Mark (IR on, positive number) and Space (IR off, negative number).",
+  "info_irscrutinizer": "Compatible with IrScrutinizer",
   "info_port_active": "Detected peripheral if in AUTO mode.",
   "info_port_location": "From the back, left to right: Ethernet — <strong>Port 1</strong> — <strong>Port 2</strong> — USB-C.",
   "info_port_pinout": "3.5 mm jack pinout",
@@ -165,6 +171,7 @@
   "t_ir_sent": "IR code sent",
   "t_ir_learn_on": "IR learning started",
   "t_ir_learn_off": "IR learning stopped",
+  "t_copied": "Copied to clipboard",
   "t_port_mode": "Port {port} mode set to {mode}",
   "t_uart_applied": "UART configuration applied",
   "t_buffering_applied": "Buffering configuration applied",
@@ -199,5 +206,6 @@
   "e_upload_auth": "Upload authentication failed",
   "e_conn_lost": "Connection lost",
   "e_upload_failed": "Upload failed: {status}",
-  "e_invalid_ip": "Invalid IPv4 address format"
+  "e_invalid_ip": "Invalid IPv4 address format",
+  "e_no_content": "No content to copy"
 }

--- a/webroot/lang/es.json
+++ b/webroot/lang/es.json
@@ -55,6 +55,8 @@
   "lbl_ir_active": "Activo",
   "lbl_mode": "Modo",
   "lbl_active": "Activo:",
+  "lbl_raw_mode": "Activar modo RAW",
+  "lbl_raw_overflow": "Desbordamiento de datos, señal IR demasiado larga",
   "lbl_baud_rate": "Velocidad en baudios",
   "lbl_data_bits": "Bits de datos",
   "lbl_stop_bits": "Bits de parada",
@@ -116,6 +118,7 @@
   "btn_resume": "Reanudar",
   "btn_start_streaming": "Iniciar transmisión",
   "btn_stop_streaming": "Detener transmisión",
+  "btn_copy": "Copiar",
 
   "info_net_cfg_ipv4": "Solo IPv4 es compatible con la configuración de red estática.",
   "info_net_cfg_restart": "El dock se reiniciará después de aplicar los cambios de red.",
@@ -127,6 +130,8 @@
   "info_ir_interval": "Intervalo en ms para enviar repetidamente el código IR mientras se mantiene presionado el botón de enviar.",
   "info_ir_learn_text": "El receptor infrarrojo está en la parte superior del dock.",
   "info_ir_protocols": "Protocolos infrarrojos compatibles",
+  "info_ir_learn_raw": "El modo RAW devuelve los valores de temporización en microsegundos, alternando entre Mark (IR activado, número positivo) y Space (IR desactivado, número negativo).",
+  "info_irscrutinizer": "Compatible con IrScrutinizer",
   "info_port_active": "Periférico detectado en modo AUTO.",
   "info_port_location": "Desde la parte trasera, de izquierda a derecha: Ethernet — <strong>Puerto 1</strong> — <strong>Puerto 2</strong> — USB-C.",
   "info_port_pinout": "Asignación de pines jack 3.5 mm",
@@ -165,6 +170,7 @@
   "t_ir_sent": "Código IR enviado",
   "t_ir_learn_on": "Aprendizaje IR iniciado",
   "t_ir_learn_off": "Aprendizaje IR detenido",
+  "t_copied": "Copiado al portapapeles",
   "t_port_mode": "Puerto {port} configurado a {mode}",
   "t_uart_applied": "Configuración UART aplicada",
   "t_buffering_applied": "Configuración de búfer aplicada",
@@ -198,5 +204,6 @@
   "e_upload_auth": "Autenticación de subida fallida",
   "e_conn_lost": "Conexión perdida",
   "e_upload_failed": "Subida fallida: {status}",
-  "e_invalid_ip": "Formato de dirección IPv4 no válido"
+  "e_invalid_ip": "Formato de dirección IPv4 no válido",
+  "e_no_content": "No hay contenido para copiar"
 }

--- a/webroot/lang/fi.json
+++ b/webroot/lang/fi.json
@@ -55,6 +55,8 @@
   "lbl_ir_active": "Aktiivinen",
   "lbl_mode": "Tila",
   "lbl_active": "Aktiivinen:",
+  "lbl_raw_mode": "Ota RAW-tila käyttöön",
+  "lbl_raw_overflow": "Datavuoto, IR-signaali liian pitkä",
   "lbl_baud_rate": "Baud-nopeus",
   "lbl_data_bits": "Databitit",
   "lbl_stop_bits": "Pysäytysbitit",
@@ -116,6 +118,7 @@
   "btn_resume": "Jatka",
   "btn_start_streaming": "Aloita suoratoisto",
   "btn_stop_streaming": "Pysäytä suoratoisto",
+  "btn_copy": "Kopioi",
 
   "info_net_cfg_ipv4": "Vain IPv4 on tuettu staattiseen verkkoasetukseen.",
   "info_net_cfg_restart": "Telakka käynnistyy uudelleen verkkoasetusten käytön jälkeen.",
@@ -127,6 +130,8 @@
   "info_ir_interval": "Väli ms:ssä IR-koodin toistuvaan lähettämiseen, kun lähetyspainiketta pidetään painettuna.",
   "info_ir_learn_text": "Infrapuna-vastaanotin on telakan yläosassa.",
   "info_ir_protocols": "Tuetut infrapuna-protokollat",
+  "info_ir_learn_raw": "RAW-tila palauttaa ajoitusarvot mikrosekunteina, vuorotellen Mark (IR päällä, positiivinen luku) ja Space (IR pois, negatiivinen luku).",
+  "info_irscrutinizer": "Yhteensopiva IrScrutinizerin kanssa",
   "info_port_active": "Tunnistettu oheislaite AUTO-tilassa.",
   "info_port_location": "Takaa katsottuna vasemmalta oikealle: Ethernet — <strong>Portti 1</strong> — <strong>Portti 2</strong> — USB-C.",
   "info_port_pinout": "3.5 mm jack -pinnijärjestys",
@@ -165,6 +170,7 @@
   "t_ir_sent": "IR-koodi lähetetty",
   "t_ir_learn_on": "IR-oppiminen aloitettu",
   "t_ir_learn_off": "IR-oppiminen pysäytetty",
+  "t_copied": "Kopioitu leikepöydälle",
   "t_port_mode": "Portin {port} tila asetettu: {mode}",
   "t_uart_applied": "UART-asetukset käytetty",
   "t_buffering_applied": "Puskurointiasetukset käytetty",
@@ -198,5 +204,6 @@
   "e_upload_auth": "Lähetyksen todennus epäonnistui",
   "e_conn_lost": "Yhteys katkesi",
   "e_upload_failed": "Lähetys epäonnistui: {status}",
-  "e_invalid_ip": "Virheellinen IPv4-osoitteen muoto"
+  "e_invalid_ip": "Virheellinen IPv4-osoitteen muoto",
+  "e_no_content": "Ei sisältöä kopioitavaksi"
 }

--- a/webroot/lang/fr.json
+++ b/webroot/lang/fr.json
@@ -55,6 +55,8 @@
   "lbl_ir_active": "Actif",
   "lbl_mode": "Mode",
   "lbl_active": "Actif :",
+  "lbl_raw_mode": "Activer le mode RAW",
+  "lbl_raw_overflow": "Débordement de données, signal IR trop long",
   "lbl_baud_rate": "Débit en bauds",
   "lbl_data_bits": "Bits de données",
   "lbl_stop_bits": "Bits d'arrêt",
@@ -116,6 +118,7 @@
   "btn_resume": "Reprendre",
   "btn_start_streaming": "Démarrer le flux",
   "btn_stop_streaming": "Arrêter le flux",
+  "btn_copy": "Copier",
 
   "info_net_cfg_ipv4": "Seul IPv4 est pris en charge pour la configuration réseau statique.",
   "info_net_cfg_restart": "Le dock redémarrera après l'application des modifications réseau.",
@@ -127,6 +130,8 @@
   "info_ir_interval": "Intervalle en ms pour envoyer répétitivement le code IR pendant que le bouton d'envoi est maintenu enfoncé.",
   "info_ir_learn_text": "Le récepteur infrarouge se trouve en haut du dock.",
   "info_ir_protocols": "Protocoles infrarouges pris en charge",
+  "info_ir_learn_raw": "Le mode RAW renvoie les valeurs de temporisation en microsecondes, en alternant entre Mark (IR activé, nombre positif) et Space (IR désactivé, nombre négatif).",
+  "info_irscrutinizer": "Compatible avec IrScrutinizer",
   "info_port_active": "Périphérique détecté en mode AUTO.",
   "info_port_location": "Depuis l'arrière, de gauche à droite: Ethernet — <strong>Port 1</strong> — <strong>Port 2</strong> — USB-C.",
   "info_port_pinout": "Brochage jack 3.5 mm",
@@ -165,6 +170,7 @@
   "t_ir_sent": "Code IR envoyé",
   "t_ir_learn_on": "Apprentissage IR démarré",
   "t_ir_learn_off": "Apprentissage IR arrêté",
+  "t_copied": "Copié dans le presse-papiers",
   "t_port_mode": "Port {port} configuré en {mode}",
   "t_uart_applied": "Configuration UART appliquée",
   "t_buffering_applied": "Configuration tampon appliquée",
@@ -198,5 +204,6 @@
   "e_upload_auth": "Authentification du téléversement échouée",
   "e_conn_lost": "Connexion perdue",
   "e_upload_failed": "Téléversement échoué : {status}",
-  "e_invalid_ip": "Format d'adresse IPv4 invalide"
+  "e_invalid_ip": "Format d'adresse IPv4 invalide",
+  "e_no_content": "Aucun contenu à copier"
 }

--- a/webroot/lang/it.json
+++ b/webroot/lang/it.json
@@ -55,6 +55,8 @@
   "lbl_ir_active": "Attivo",
   "lbl_mode": "Modalità",
   "lbl_active": "Attivo:",
+  "lbl_raw_mode": "Abilita modalità RAW",
+  "lbl_raw_overflow": "Overflow dati, segnale IR troppo lungo",
   "lbl_baud_rate": "Baud Rate",
   "lbl_data_bits": "Bit di dati",
   "lbl_stop_bits": "Bit di stop",
@@ -116,6 +118,7 @@
   "btn_resume": "Riprendi",
   "btn_start_streaming": "Avvia streaming",
   "btn_stop_streaming": "Arresta streaming",
+  "btn_copy": "Copia",
 
   "info_net_cfg_ipv4": "Solo IPv4 è supportato per la configurazione di rete statica.",
   "info_net_cfg_restart": "Il dock si riavvierà dopo l'applicazione delle modifiche di rete.",
@@ -127,6 +130,8 @@
   "info_ir_interval": "Intervallo in ms per inviare ripetutamente il codice IR mentre il pulsante di invio è tenuto premuto.",
   "info_ir_learn_text": "Il ricevitore a infrarossi si trova nella parte superiore del dock.",
   "info_ir_protocols": "Protocolli a infrarossi supportati",
+  "info_ir_learn_raw": "La modalità RAW restituisce i valori di temporizzazione in microsecondi, alternando tra Mark (IR acceso, numero positivo) e Space (IR spento, numero negativo).",
+  "info_irscrutinizer": "Compatibile con IrScrutinizer",
   "info_port_active": "Periferica rilevata in modalità AUTO.",
   "info_port_location": "Dal retro, da sinistra a destra: Ethernet — <strong>Port 1</strong> — <strong>Port 2</strong> — USB-C.",
   "info_port_pinout": "Pinout jack 3.5 mm",
@@ -165,6 +170,7 @@
   "t_ir_sent": "Codice IR inviato",
   "t_ir_learn_on": "Apprendimento IR avviato",
   "t_ir_learn_off": "Apprendimento IR fermato",
+  "t_copied": "Copiato negli appunti",
   "t_port_mode": "Porta {port} impostata su {mode}",
   "t_uart_applied": "Configurazione UART applicata",
   "t_buffering_applied": "Configurazione buffering applicata",
@@ -198,5 +204,6 @@
   "e_upload_auth": "Autenticazione caricamento fallita",
   "e_conn_lost": "Connessione persa",
   "e_upload_failed": "Caricamento fallito: {status}",
-  "e_invalid_ip": "Formato indirizzo IPv4 non valido"
+  "e_invalid_ip": "Formato indirizzo IPv4 non valido",
+  "e_no_content": "Nessun contenuto da copiare"
 }

--- a/webroot/lang/nl.json
+++ b/webroot/lang/nl.json
@@ -67,6 +67,8 @@
   "lbl_ir_active": "Actief",
   "lbl_mode": "Modus",
   "lbl_active": "Actief:",
+  "lbl_raw_mode": "RAW-modus inschakelen",
+  "lbl_raw_overflow": "Gegevensoverloop, IR-signaal te lang",
   "lbl_baud_rate": "Baudrate",
   "lbl_data_bits": "Databits",
   "lbl_stop_bits": "Stopbits",
@@ -116,6 +118,7 @@
   "btn_resume": "Hervatten",
   "btn_start_streaming": "Streaming starten",
   "btn_stop_streaming": "Streaming stoppen",
+  "btn_copy": "Kopiëren",
 
   "info_net_cfg_ipv4": "Alleen IPv4 wordt ondersteund voor statische netwerkconfiguratie.",
   "info_net_cfg_restart": "De dock wordt herstart na het toepassen van netwijzigingen.",
@@ -127,6 +130,8 @@
   "info_ir_interval": "Interval in ms om de IR-code herhaaldelijk te verzenden terwijl de verzendknop wordt ingedrukt.",
   "info_ir_learn_text": "De infrarood-ontvanger bevindt zich bovenaan het dock.",
   "info_ir_protocols": "Ondersteunde infrarood-protocollen",
+  "info_ir_learn_raw": "RAW-modus retourneert de timingwaarden in microseconden, afwisselend tussen Mark (IR aan, positief getal) en Space (IR uit, negatief getal).",
+  "info_irscrutinizer": "Compatibel met IrScrutinizer",
   "info_port_active": "Gedetecteerd randapparaat in AUTO-modus.",
   "info_port_location": "Vanaf de achterkant, van links naar rechts: Ethernet — <strong>Poort 1</strong> — <strong>Poort 2</strong> — USB-C.",
   "info_port_pinout": "3.5 mm jack pinout",
@@ -165,6 +170,7 @@
   "t_ir_sent": "IR-code verzonden",
   "t_ir_learn_on": "IR-leren gestart",
   "t_ir_learn_off": "IR-leren gestopt",
+  "t_copied": "Gekopieerd naar klembord",
   "t_port_mode": "Poort {port} ingesteld op {mode}",
   "t_uart_applied": "UART-configuratie toegepast",
   "t_buffering_applied": "Bufferingconfiguratie toegepast",
@@ -198,5 +204,6 @@
   "e_upload_auth": "Upload-authenticatie mislukt",
   "e_conn_lost": "Verbinding verloren",
   "e_upload_failed": "Upload mislukt: {status}",
-  "e_invalid_ip": "Ongeldig IPv4-adresformaat"
+  "e_invalid_ip": "Ongeldig IPv4-adresformaat",
+  "e_no_content": "Geen inhoud om te kopiëren"
 }

--- a/webroot/lang/no.json
+++ b/webroot/lang/no.json
@@ -55,6 +55,8 @@
   "lbl_ir_active": "Aktiv",
   "lbl_mode": "Modus",
   "lbl_active": "Aktiv:",
+  "lbl_raw_mode": "Aktiver RAW-modus",
+  "lbl_raw_overflow": "Dataoverflyt, IR-signal for langt",
   "lbl_baud_rate": "Baud-rate",
   "lbl_data_bits": "Databiter",
   "lbl_stop_bits": "Stoppbiter",
@@ -116,6 +118,7 @@
   "btn_resume": "Fortsett",
   "btn_start_streaming": "Start strømming",
   "btn_stop_streaming": "Stopp strømming",
+  "btn_copy": "Kopier",
 
   "info_net_cfg_ipv4": "Kun IPv4 støttes for statisk nettverkskonfigurasjon.",
   "info_net_cfg_restart": "Docken starter på nytt etter at nettverksendringer er brukt.",
@@ -127,6 +130,8 @@
   "info_ir_interval": "Intervall i ms for gjentatt sending av IR-koden mens sendeknappen holdes nede.",
   "info_ir_learn_text": "Infrarød-mottakeren er plassert øverst på docken.",
   "info_ir_protocols": "Støttede infrarøde protokoller",
+  "info_ir_learn_raw": "RAW-modus returnerer tidsverdiene i mikrosekunder, vekslende mellom Mark (IR på, positivt tall) og Space (IR av, negativt tall).",
+  "info_irscrutinizer": "Kompatibel med IrScrutinizer",
   "info_port_active": "Registrert periferienhet i AUTO-modus.",
   "info_port_location": "Fra baksiden, venstre til høyre: Ethernet — <strong>Port 1</strong> — <strong>Port 2</strong> — USB-C.",
   "info_port_pinout": "3.5 mm jack pinout",
@@ -165,6 +170,7 @@
   "t_ir_sent": "IR-kode sendt",
   "t_ir_learn_on": "IR-læring startet",
   "t_ir_learn_off": "IR-læring stoppet",
+  "t_copied": "Kopiert til utklippstavlen",
   "t_port_mode": "Port {port} modus satt til {mode}",
   "t_uart_applied": "UART-konfigurasjon brukt",
   "t_buffering_applied": "Buffering-konfigurasjon brukt",
@@ -198,5 +204,6 @@
   "e_upload_auth": "Opplasting-autentisering mislyktes",
   "e_conn_lost": "Tilkobling tapt",
   "e_upload_failed": "Opplasting mislyktes: {status}",
-  "e_invalid_ip": "Ugyldig IPv4-adresseformat"
+  "e_invalid_ip": "Ugyldig IPv4-adresseformat",
+  "e_no_content": "Ingen innhold å kopiere"
 }

--- a/webroot/lang/pt.json
+++ b/webroot/lang/pt.json
@@ -55,6 +55,8 @@
   "lbl_ir_active": "Ativo",
   "lbl_mode": "Modo",
   "lbl_active": "Ativo:",
+  "lbl_raw_mode": "Ativar modo RAW",
+  "lbl_raw_overflow": "Overflow de dados, sinal IR muito longo",
   "lbl_baud_rate": "Baud Rate",
   "lbl_data_bits": "Bits de dados",
   "lbl_stop_bits": "Bits de paragem",
@@ -116,6 +118,7 @@
   "btn_resume": "Retomar",
   "btn_start_streaming": "Iniciar transmissão",
   "btn_stop_streaming": "Parar transmissão",
+  "btn_copy": "Copiar",
 
   "info_net_cfg_ipv4": "Apenas IPv4 é suportado para configuração de rede estática.",
   "info_net_cfg_restart": "O dock será reiniciado após aplicar as alterações de rede.",
@@ -127,6 +130,8 @@
   "info_ir_interval": "Intervalo em ms para enviar repetidamente o código IR enquanto o botão de enviar é mantido pressionado.",
   "info_ir_learn_text": "O receptor infravermelho está na parte superior do dock.",
   "info_ir_protocols": "Protocolos infravermelhos suportados",
+  "info_ir_learn_raw": "O modo RAW retorna os valores de temporização em microssegundos, alternando entre Mark (IR ligado, número positivo) e Space (IR desligado, número negativo).",
+  "info_irscrutinizer": "Compatível com IrScrutinizer",
   "info_port_active": "Periférico detectado no modo AUTO.",
   "info_port_location": "De trás, da esquerda para a direita: Ethernet — <strong>Porta 1</strong> — <strong>Porta 2</strong> — USB-C.",
   "info_port_pinout": "Pinout jack 3.5 mm",
@@ -165,6 +170,7 @@
   "t_ir_sent": "Código IR enviado",
   "t_ir_learn_on": "Aprendizagem IR iniciada",
   "t_ir_learn_off": "Aprendizagem IR parada",
+  "t_copied": "Copiado para a área de transferência",
   "t_port_mode": "Porta {port} configurada para {mode}",
   "t_uart_applied": "Configuração UART aplicada",
   "t_buffering_applied": "Configuração de buffering aplicada",
@@ -198,5 +204,6 @@
   "e_upload_auth": "Autenticação de carregamento falhada",
   "e_conn_lost": "Ligação perdida",
   "e_upload_failed": "Carregamento falhado: {status}",
-  "e_invalid_ip": "Formato de endereço IPv4 inválido"
+  "e_invalid_ip": "Formato de endereço IPv4 inválido",
+  "e_no_content": "Sem conteúdo para copiar"
 }

--- a/webroot/lang/sv.json
+++ b/webroot/lang/sv.json
@@ -55,6 +55,8 @@
   "lbl_ir_active": "Aktiv",
   "lbl_mode": "Läge",
   "lbl_active": "Aktiv:",
+  "lbl_raw_mode": "Aktivera RAW-läge",
+  "lbl_raw_overflow": "Dataöverflöde, IR-signal för lång",
   "lbl_baud_rate": "Baud-hastighet",
   "lbl_data_bits": "Databitar",
   "lbl_stop_bits": "Stoppbitar",
@@ -116,6 +118,7 @@
   "btn_resume": "Fortsätt",
   "btn_start_streaming": "Starta strömning",
   "btn_stop_streaming": "Stoppa strömning",
+  "btn_copy": "Kopiera",
 
   "info_net_cfg_ipv4": "Endast IPv4 stöds för statisk nätverkskonfiguration.",
   "info_net_cfg_restart": "Docken startas om efter att nätverksändringar har tillämpats.",
@@ -127,6 +130,8 @@
   "info_ir_interval": "Intervall i ms för att upprepade gånger skicka IR-koden medan sändarknappen hålls nedtryckt.",
   "info_ir_learn_text": "Infraröd-mottagaren är placerad högst upp på docken.",
   "info_ir_protocols": "Infraröda protokoll som stöds",
+  "info_ir_learn_raw": "RAW-läge returnerar tidsvärdena i mikrosekunder, växlande mellan Mark (IR på, positivt tal) och Space (IR av, negativt tal).",
+  "info_irscrutinizer": "Kompatibel med IrScrutinizer",
   "info_port_active": "Identifierad kringutrustning i AUTO-läge.",
   "info_port_location": "Bakifrån, vänster till höger: Ethernet — <strong>Port 1</strong> — <strong>Port 2</strong> — USB-C.",
   "info_port_pinout": "3.5 mm jack pinout",
@@ -165,6 +170,7 @@
   "t_ir_sent": "IR-kod skickad",
   "t_ir_learn_on": "IR-inlärning startad",
   "t_ir_learn_off": "IR-inlärning stoppad",
+  "t_copied": "Kopierat till urklipp",
   "t_port_mode": "Port {port} läge satt till {mode}",
   "t_uart_applied": "UART-konfiguration verkställd",
   "t_buffering_applied": "Buffringskonfiguration verkställd",
@@ -198,5 +204,6 @@
   "e_upload_auth": "Uppladdningsautentisering misslyckades",
   "e_conn_lost": "Anslutning förlorad",
   "e_upload_failed": "Uppladdning misslyckades: {status}",
-  "e_invalid_ip": "Ogiltigt IPv4-adressformat"
+  "e_invalid_ip": "Ogiltigt IPv4-adressformat",
+  "e_no_content": "Inget innehåll att kopiera"
 }


### PR DESCRIPTION
The RAW IR learning mode captures and displays the raw IR timing values in addition to the decoded IR code. This is useful for advanced users, debugging, and compatibility with IR analysis tools like [IrScrutinizer](https://github.com/bengtmartensson/IrScrutinizer).

Raw IR timings are enabled with the new optional `"raw": true` field in the `ir_receive_on` request message:

```json
{
  "type": "dock",
  "command": "ir_receive_on",
  "raw": true
}
```

The `ir_receive` event message contains a `raw` array with signed timing values (Mark / Space pairs) in microseconds.

Example:
```json
{
    "type": "event",
    "msg": "ir_receive",
    "format": "hex",
    "ir_code": "4;0xA10;12;0",
    "overflow": false,
    "raw": [3344,-1704,388,-448,388,-448,388,-1286,388,-450,390,-1284,388,-448,388,-1286,388,-450,386,-448,388,-1286,388,-448,388,-448,388,-1286,388,-1286,388,-448,388,-448,388,-448,388,-448,388,-448,388,-448,388,-1286,388,-448,388,-1286,388,-448,388,-1286,388,-448,388,-448,388,-448,388,-1286,388,-448,388,-1286,388,-448,388,-1286,388,-448,388,-448,388,-448,388,-448,388,-448,388,-1286,388,-448,388,-448,388,-448,388,-448,388,-456,380,-448,388,-448,388,-1286,388,-448,388]
}
```

- `format` is set to the format of the `ir_code` value, similar as in the `ir_send` message. Only `hex` for now. 
- `ir_code` is empty if the IR code could not be decoded.
- `overflow` is set to `true` if the IR signal was too long and didn't fit into the receive buffer.
- `raw`: optional Mark / Space values in microseconds, if requsted in `ir_receive_on`.


### Management web-UI addition:

<img width="679" height="602" alt="image" src="https://github.com/user-attachments/assets/d18c4a61-9f64-4aac-9b3b-e76bd259564b" />

**Interaction Flow:**

1. User navigates to IR page
2. User checks "Enable RAW mode" checkbox (only possible when learning is stopped)
3. Raw output panel becomes visible
4. User clicks "Start Learning"
5. WebSocket sends: `{"type":"dock","command":"ir_receive_on","raw":true}`
6. User points original IR-remote at dock and presses button
7. Dock responds with `ir_receive` event containing `ir_code` and `raw` array
8. `ir_code` appended to Decoded IR Code console (existing behavior)
9. `raw` array displayed in Raw Timings panel (replaces previous value)
10. If `overflow: true`, warning appears until next message
11. User clicks "Copy" to copy raw timings to clipboard (clean format)
12. User clicks "Stop Learning" to end session


Closes #11 

---

LLM disclaimer: assisted with Qwen3.5-397B-A17B and Claude, manually verified and refined.