### PR TITLE
refactor: disable action buttons when WebSocket disconnected

### DIFF
--- a/doc/web-management-ui.md
+++ b/doc/web-management-ui.md
@@ -143,6 +143,52 @@ This might be changed if more pages are added.
 - **Login link**: Available in header when not authenticated
 - **Logout**: Clears token, closes WebSocket, navigates to Status
 - **Inactivity timeout**: Automatically disconnects after 10 minutes of inactivity (see below)
+- **Action disabling**: All action buttons are disabled when WebSocket is not connected and authenticated
+
+### Action Disabling on Disconnect
+
+To prevent confusing timeout errors and provide clear visual feedback, all action buttons are automatically disabled when the WebSocket connection is not active.
+
+**Connection State:**
+- Actions are enabled only when `WS.authenticated === true` AND `WS.socket.readyState === 1` (OPEN)
+- Actions are disabled immediately on disconnect, authentication failure, or page load
+- Actions are re-enabled automatically when connection is restored and authentication succeeds
+
+**Disabled Actions (when disconnected):**
+
+| Page     | Disabled Buttons                                                                      |
+|----------|---------------------------------------------------------------------------------------|
+| General  | Save (name), Apply (brightness), Change (token), Identify, Reboot, Factory Reset      |
+| Network  | Apply (ethernet), Apply (WiFi network), Apply (WiFi configuration), Apply (DNS)       |
+| IR       | Send IR, Start/Stop Learning                                                          |
+| Ports    | Apply mode, Apply UART, Apply Buffering, Enable Console, Send, Trigger ON/OFF/Impulse |
+| Logs     | Start/Stop Streaming                                                                  |
+| Expert   | Apply                                                                                 |
+
+**Elements That Remain Enabled:**
+
+| Element Type           | Examples                                            | Reason                                     |
+|------------------------|-----------------------------------------------------|--------------------------------------------|
+| Form inputs            | All text fields, selects, checkboxes, range sliders | Simplifies logic, allows preparing changes |
+| Clear/Copy buttons     | IR Clear, IR Copy Raw, Port Clear, Log Clear        | Local operations, no WebSocket needed      |
+| Info popover buttons   | All `i` info triggers                               | Documentation, no WebSocket needed         |
+| Password reveal toggle | WiFi Show/Hide password                             | UI-only, no WebSocket needed               |
+| Navigation tabs        | All page navigation                                 | Triggers reconnection                      |
+| Footer controls        | Language selector, Theme selector                   | User preferences                           |
+| OTA controls           | File input, Upload button                           | Uses HTTP POST, not WebSocket              |
+
+**Visual Feedback:**
+- Disabled buttons use CSS styling: `opacity: 0.4`, `cursor: default`
+- The connection status indicator in the header shows the current state (Connected/Disconnected/Connecting)
+- No timeout errors when clicking disabled buttons (standard HTML behavior)
+
+**State Change Points:**
+- `WS.socket.onclose` → disable actions
+- `WS.onMessage` authentication success → enable actions
+- `WS.onMessage` authentication failure → disable actions
+- `WS.rejectAllPending` → disable actions
+- `UI.init()` → disable actions on page load
+- `UI.onAuthenticated()` → enable actions after auth
 
 ### Inactivity Timeout
 
@@ -254,6 +300,8 @@ Event (dock to client, unsolicited):
 - On reconnect: auto-authenticate with stored token
 - On auth failure after reconnect: show login dialog
 - All pending promises are rejected on disconnect
+- Action buttons remain disabled during reconnection
+- Navigation tabs remain functional and trigger reconnection
 
 ### Token Storage
 
@@ -735,6 +783,25 @@ Key points:
 - Do not refactor things that are not broken
 - Do not remove existing code comments unless they are invalidated by your changes
 - If you notice unrelated dead code, mention it but do not delete it
+
+### Action Button IDs
+
+When adding new action buttons that send WebSocket commands, add the button ID to the `UI.actionButtonIds` array in `app.js` to ensure it is disabled when disconnected:
+
+```javascript
+UI = {
+  actionButtonIds: [
+    // General
+    'btn-save-name', 'btn-save-brightness', 'btn-save-token',
+    'btn-identify', 'btn-reboot', 'btn-reset',
+    // ... existing IDs ...
+    // New button ID here
+  ],
+  // ...
+}
+```
+
+**Exception:** Do not add buttons that perform local operations only (clear console, copy to clipboard, etc.) or use HTTP instead of WebSocket (OTA upload).
 
 ### HTML ID Naming
 

--- a/webroot/app.js
+++ b/webroot/app.js
@@ -166,6 +166,7 @@ const WS = {
   })(),
   token: null,
   authenticated: false,
+  actionsEnabled: false,
   msgId: 0,
   pending: {},
   reconnectMs: 2000,
@@ -198,6 +199,7 @@ const WS = {
     this.socket.onclose = function () {
       self.authenticated = false;
       self.rejectAllPending();
+      self.updateActionState();
       if (self.keepConnected) {
         self.scheduleReconnect();
       }
@@ -247,6 +249,7 @@ const WS = {
         this.startStatusRefresh();
         this.keepConnected = true;
         this.startInactivityTimer();
+        this.updateActionState();
       } else {
         this.token = null;
         sessionStorage.removeItem("token");
@@ -254,6 +257,7 @@ const WS = {
         UI.showLogin(I18N.t("e_invalid_token"));
         this.stopStatusRefresh();
         this.stopInactivityTimer();
+        this.updateActionState();
       }
       return;
     }
@@ -375,6 +379,7 @@ const WS = {
     this.stopStatusRefresh();
     this.stopInactivityTimer();
     this.resetClientState();
+    this.updateActionState();
   },
 
   resetClientState: function () {
@@ -507,6 +512,12 @@ const WS = {
     if (this.authenticated) {
       this.resetInactivityTimer();
     }
+  },
+
+  updateActionState: function () {
+    const enabled = this.authenticated && this.socket && this.socket.readyState === 1;
+    this.actionsEnabled = enabled;
+    UI.setActionsEnabled(enabled);
   }
 
 };
@@ -559,6 +570,27 @@ const UI = {
   pendingPage: null,
   authRequired: {general: true, network: true, ir: true, ports: true, ota: true, logs: true, expert: true},
   sysInfoCache: null,
+  actionButtonIds: [
+    // General
+    'btn-save-name', 'btn-save-brightness', 'btn-save-token',
+    'btn-identify', 'btn-reboot', 'btn-reset',
+    // Network
+    'btn-save-eth', 'btn-save-wifi', 'btn-save-wifi-net', 'btn-save-dns',
+    // IR
+    'btn-ir-send', 'btn-ir-learn',
+    // Ports
+    'btn-port1-mode', 'btn-port2-mode',
+    'btn-port1-uart', 'btn-port2-uart',
+    'btn-port1-serial-cfg', 'btn-port2-serial-cfg',
+    'btn-port1-console', 'btn-port2-console',
+    'btn-port1-send', 'btn-port2-send',
+    'btn-port1-trig-on', 'btn-port1-trig-off', 'btn-port1-impulse',
+    'btn-port2-trig-on', 'btn-port2-trig-off', 'btn-port2-impulse',
+    // Logs
+    'btn-log-stream',
+    // Expert
+    'btn-expert-apply'
+  ],
 
   init: function () {
     const self = this;
@@ -614,6 +646,9 @@ const UI = {
 
     // Set connection mode based on auth state
     WS.keepConnected = !!WS.token;
+
+    // Disable all actions until connected and authenticated
+    this.setActionsEnabled(false);
 
     // Connect WebSocket
     WS.connect();
@@ -687,6 +722,7 @@ const UI = {
     this.pendingPage = null;
     this.showPage(page);
     this.updateLogoutVisibility();
+    WS.updateActionState();
   },
 
   updateLogoutVisibility: function () {
@@ -706,6 +742,16 @@ const UI = {
     }
     text.textContent = I18N.t("st_" + (state === "connecting" ? "connecting" : (state === "ok" ? "connected" : "disconnected")));
     this.updateLogoutVisibility();
+  },
+
+  setActionsEnabled: function (enabled) {
+    const self = this;
+    this.actionButtonIds.forEach(function (id) {
+      const btn = document.getElementById(id);
+      if (btn) {
+        btn.disabled = !enabled;
+      }
+    });
   },
 
   showLogin: function (errMsg) {


### PR DESCRIPTION
Prevent confusing timeout errors by disabling all action buttons that require WebSocket communication when the connection is not active.

Changes:
- Add WS.actionsEnabled property to track connection state
- Add WS.updateActionState() to check auth + socket.readyState
- Add UI.actionButtonIds array with all action button IDs
- Add UI.setActionsEnabled() to disable/enable action buttons
- Call updateActionState() at all connection state change points:
  * Socket close
  * Authentication success/failure
  * Reject all pending requests
  * Page initialization
  * After successful authentication

Disabled when disconnected:
- General: Save, Apply, Change token, Identify, Reboot, Factory Reset
- Network: All Apply buttons (ethernet, WiFi, DNS)
- IR: Send, Start/Stop Learning
- Ports: Apply mode/UART/Buffering, Enable Console, Send, Trigger
- Logs: Start/Stop Streaming
- Expert: Apply

Remains enabled:
- All form inputs (simplifies logic, allows preparing changes)
- Clear/Copy buttons (local operations, no WebSocket needed)
- Info popover buttons (documentation)
- Password reveal toggle (UI-only)
- Navigation tabs (triggers reconnection)
- Footer controls (language/theme selectors)
- OTA controls (uses HTTP POST, not WebSocket)

Visual feedback:
- Disabled buttons show opacity: 0.4, cursor: default
- Connection status indicator in header shows current state
- No timeout errors when clicking disabled buttons

Documentation:
- Update web-management-ui.md with Action Disabling section
- Document disabled/enabled elements
- Add coding convention for new action button IDs

Fixes user confusion from 10-second timeout errors when clicking actions while disconnected.

---

LLM disclaimer: assisted with Qwen3.5-397B-A17B.