### PR TITLE
feat: improve iTach compatibility, support get_IRL command

### DIFF
--- a/components/infrared/globalcache.cpp
+++ b/components/infrared/globalcache.cpp
@@ -4,9 +4,17 @@
 
 #include "globalcache.h"
 
+#include <inttypes.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
 uint8_t parseGcRequest(const char *request, GCMsg *msg) {
     if (request == nullptr || msg == nullptr) {
-        return false;
+        return 17;  // bad command syntax
     }
 
     // command
@@ -72,4 +80,102 @@ uint8_t parseGcRequest(const char *request, GCMsg *msg) {
     }
 
     return 0;
+}
+
+/// Count decimal digits of a uint32_t value.
+static size_t uint32_digits(uint32_t val) {
+    if (val == 0) return 1;
+    size_t digits = 0;
+    while (val > 0) {
+        val /= 10;
+        digits++;
+    }
+    return digits;
+}
+
+char *raw_timings_to_gc_sendir(const uint16_t *timings_us, uint16_t timings_len, uint32_t frequency_hz,
+                               const char *connector, uint16_t id) {
+    if (timings_us == NULL || timings_len == 0 || frequency_hz == 0 || connector == NULL) {
+        return NULL;
+    }
+
+    // Frequency must be within iTach range: 15000-500000
+    if (frequency_hz < 15000 || frequency_hz > 500000) {
+        return NULL;
+    }
+
+    // First pass: count logical pulses, compute exact string length,
+    // and determine last value for potential odd-count duplication.
+    // This is optimized for memory usage on ESP32, not compute efficiency!
+    // It is not a time critical operation, only called once after a learned IR signal,
+    // the 2 passes are acceptable
+    uint16_t logical_count = 0;
+    uint32_t last_periods = 0;
+    size_t   values_len = 0;  // total chars for all comma-separated values
+    uint16_t i = 0;
+
+    while (i < timings_len) {
+        uint32_t total_us = timings_us[i];
+        i++;
+        while (i + 1 < timings_len && timings_us[i] == 0) {
+            i++;
+            total_us += timings_us[i];
+            i++;
+        }
+        last_periods = (uint32_t)(((uint64_t)total_us * frequency_hz + 500000) / 1000000);
+        if (last_periods == 0) {
+            last_periods = 1;
+        }
+        values_len += 1 + uint32_digits(last_periods);  // comma + digits
+        logical_count++;
+    }
+
+    if (logical_count == 0) {
+        return NULL;
+    }
+
+    // Account for duplicated OFF if odd count.
+    if (logical_count % 2 != 0) {
+        values_len += 1 + uint32_digits(last_periods);
+    }
+
+    // Calculate exact header length.
+    // "sendir," + connector + "," + id + "," + freq + ",1,1"
+    size_t header_len = 7 + strlen(connector) + 1 + uint32_digits(id) + 1 + uint32_digits(frequency_hz) + 4;
+
+    size_t buf_size = header_len + values_len + 2;  // +2 for \r + null terminator
+    char  *buf = (char *)malloc(buf_size);
+    if (buf == NULL) {
+        return NULL;
+    }
+
+    int offset = snprintf(buf, buf_size, "sendir,%s,%u,%" PRIu32 ",1,1", connector, id, frequency_hz);
+
+    // Second pass: convert and write values.
+    i = 0;
+    while (i < timings_len) {
+        uint32_t total_us = timings_us[i];
+        i++;
+        while (i + 1 < timings_len && timings_us[i] == 0) {
+            i++;
+            total_us += timings_us[i];
+            i++;
+        }
+        uint32_t periods = (uint32_t)(((uint64_t)total_us * frequency_hz + 500000) / 1000000);
+        if (periods == 0) {
+            periods = 1;
+        }
+        offset += snprintf(buf + offset, buf_size - offset, ",%lu", (unsigned long)periods);
+    }
+
+    if (logical_count % 2 != 0) {
+        offset += snprintf(buf + offset, buf_size - offset, ",%lu", (unsigned long)last_periods);
+    }
+
+    if (offset < buf_size - 1) {
+        buf[offset] = '\r';
+        buf[offset + 1] = '\0';
+    }
+
+    return buf;
 }

--- a/components/infrared/globalcache.h
+++ b/components/infrared/globalcache.h
@@ -9,9 +9,6 @@
 
 #include <stdint.h>
 
-#include <algorithm>
-#include <cstring>
-
 #include "util_types.h"
 
 /// @brief Parse a GlobalCache request message
@@ -29,3 +26,22 @@
 /// - get_IRL
 /// - stop_IRL
 uint8_t parseGcRequest(const char *request, GCMsg *msg);
+
+/// Convert raw microsecond timings to Global Caché sendir format string.
+/// Handles overflow encoding where values > UINT16_MAX are split into
+/// multiple entries with 0 as skip marker in the opposite position.
+///
+/// Parameters:
+///   timings_us   - raw timing array (unsigned µs, alternating mark/space)
+///   timings_len  - number of entries
+///   frequency_hz - carrier frequency in Hz
+///   connector    - connector address string, e.g. "1:1"
+///   id           - sendir ID (0-65535)
+///
+/// If the number of logical pulses is odd, the last value is duplicated as
+/// final OFF.
+///
+/// Returns heap-allocated string, ending with \r. Caller must free().
+/// Returns NULL on invalid input.
+char *raw_timings_to_gc_sendir(const uint16_t *timings_us, uint16_t timings_len, uint32_t frequency_hz,
+                               const char *connector, uint16_t id);

--- a/components/infrared/globalcache_server.cpp
+++ b/components/infrared/globalcache_server.cpp
@@ -20,6 +20,7 @@
 
 #include "esp_event.h"
 #include "esp_log.h"
+#include "esp_mac.h"
 
 #include "globalcache.h"
 #include "sdkconfig.h"
@@ -210,7 +211,10 @@ void GlobalCacheServer::tcp_server_task(void *param) {
             continue;
         }
         client->socket = sock;
-        snprintf(client->mac, sizeof(client->mac), "%s", gc->m_config->getHostName() + 9);
+        uint8_t mac[6];
+        esp_read_mac(mac, ESP_MAC_WIFI_STA);
+        snprintf(client->mac, sizeof(client->mac), "%02X%02X%02X%02X%02X%02X", mac[0], mac[1], mac[2], mac[3], mac[4],
+                 mac[5]);
         client->semaphore = clientCountSemaphore;
         client->irService = gc->m_irService;
         if (xTaskCreatePinnedToCore(socket_task,     // task function
@@ -240,137 +244,186 @@ void GlobalCacheServer::socket_task(void *param) {
     GCClient *client = reinterpret_cast<GCClient *>(param);
 
     int  len = 0;
+    int  total_len = 0;
     char rx_buffer[1024];
 
     while (true) {
-        // Optimistic reading, get as much data as possible, max request message size is limited to 1 KB,
-        // but that should be sufficient for large IR commands.
-        // TODO(zehnm) read until message terminator / buffer full.
-        len = recv(client->socket, rx_buffer, sizeof(rx_buffer) - 1, 0);
+        len = recv(client->socket, rx_buffer + total_len, sizeof(rx_buffer) - total_len - 1, 0);
         if (len <= 0) {
             break;
         }
-        // Null-terminate whatever is received and treat it like a string
-        rx_buffer[len] = 0;
-        ESP_LOGD(TAG_GC, "[%d] Received %d bytes: %s", client->socket, len, rx_buffer);
+        total_len += len;
+        rx_buffer[total_len] = 0;
+        ESP_LOGD(TAG_GC, "[%d] Received %d bytes, total in buffer: %d", client->socket, len, total_len);
 
-        // find message terminator
-        char *end = strchr(rx_buffer, '\r');
-        if (end == NULL) {
+        char *ptr = rx_buffer;
+        char *end_of_cmd;
+        bool  should_break = false;
+
+        while ((end_of_cmd = strchr(ptr, '\r')) != NULL) {
+            *end_of_cmd = 0;
+            char *current_cmd = ptr;
+            ptr = end_of_cmd + 1;
+
+            // find start of message, skip all non graphical representation characters
+            // https://en.cppreference.com/w/c/string/byte/isgraph
+            while (current_cmd != end_of_cmd && !isgraph(*current_cmd)) {
+                current_cmd++;
+            }
+            if (current_cmd == end_of_cmd) {
+                // ignore, no error (as iTach device)
+                continue;
+            }
+
+            GCMsg req;
+            auto  result = parseGcRequest(current_cmd, &req);
+            if (result) {
+                char buf[16];
+                // global cache iTach error code
+                snprintf(buf, sizeof(buf), "ERR_1:1,%03d\r", result);
+                if (!send_string_to_socket(client->socket, buf)) {
+                    should_break = true;
+                    break;
+                }
+                continue;
+            }
+
+            ESP_LOGD(TAG_GC, "Command: %s,%d:%d,%s", req.command, req.module, req.port, req.param ? req.param : "");
+
+            // API spec: disable learning if any other command is sent
+            if (client->irService->isIrLearning() && strcmp(req.command, "stop_IRL") != 0) {
+                client->irService->stopIrLearn();
+            }
+
+            if (strcmp(req.command, "sendir") == 0) {
+                int16_t  clientId = IR_CLIENT_GC;
+                uint32_t msgId = atoi(req.param);  // this _should_ point to ID
+                auto     res = client->irService->sendGlobalCache(clientId, msgId, current_cmd, client->socket);
+                ESP_LOGD(TAG_GC, "[%d] sendGlobalCache result: %d", client->socket, res);
+
+                char        buf[17];
+                const char *msg = nullptr;
+                if (res == 0 || res == 200) {
+                    // OK, async callback over the passed socket (code 200 shouldn't be used anymore)
+                } else if (res == 202) {
+                    // accepted IR repeat. Original iTach device doesn't send a reply, so we do the same!
+                } else if (res > 0 && res < 100) {
+                    // global cache iTach error code
+                    snprintf(buf, sizeof(buf), "ERR_%d:%d,%03d\r", req.module, req.port, res);
+                    msg = buf;
+                } else if (res == 500) {
+                    // invalid parameter
+                    snprintf(buf, sizeof(buf), "ERR_%d:%d,023\r", req.module, req.port);
+                    msg = buf;
+                } else if (res == 429 || res == 503) {
+                    msg = "busyir\r";
+                } else {
+                    // invalid command (unknown)
+                    snprintf(buf, sizeof(buf), "ERR_%d:%d,001\r", req.module, req.port);
+                    msg = buf;
+                }
+
+                if (msg && !send_string_to_socket(client->socket, msg)) {
+                    should_break = true;
+                    break;
+                }
+            } else if (strcmp(req.command, "stopir") == 0) {
+                client->irService->stopSend();
+                char reply[16];
+                snprintf(reply, sizeof(reply), "%.12s\r", current_cmd);
+                if (!send_string_to_socket(client->socket, reply)) {
+                    should_break = true;
+                    break;
+                }
+            } else if (strcmp(req.command, "getdevices") == 0) {
+                if (!send_string_to_socket(client->socket, "device,0,0 ETHERNET\r")) {
+                    should_break = true;
+                    break;
+                }
+                int  ports = 4;
+                char msg[64];
+                snprintf(msg, sizeof(msg), "device,0,0 WIFI\rdevice,1,%d IR\rendlistdevices\r", ports);
+                if (!send_string_to_socket(client->socket, msg)) {
+                    should_break = true;
+                    break;
+                }
+            } else if (strcmp(req.command, "getversion") == 0) {
+                // GlobalCache iHelp doesn't like dots in version string, or device doesn't show up!
+                char version[30];
+                snprintf(version, sizeof(version), "%s\r", DOCK_VERSION[0] == 'v' ? DOCK_VERSION + 1 : DOCK_VERSION);
+                replacechar(version, '.', '-');
+                replacechar(version, '+', '-');
+                if (!send_string_to_socket(client->socket, version)) {
+                    should_break = true;
+                    break;
+                }
+            } else if (strcmp(req.command, "getmac") == 0) {
+                // command discovered with iHelp
+                char mac[30];
+                snprintf(mac, sizeof(mac), "MACaddress,%s\r", client->mac);
+                if (!send_string_to_socket(client->socket, mac)) {
+                    should_break = true;
+                    break;
+                }
+            } else if (strcmp(req.command, "blink") == 0) {
+                ESP_ERROR_CHECK_WITHOUT_ABORT(
+                    esp_event_post(UC_DOCK_EVENTS, UC_ACTION_IDENTIFY, NULL, 0, pdMS_TO_TICKS(200)));
+            } else if (strcmp(req.command, "get_IRL") == 0) {
+                int clientSocket = client->socket;
+                client->irService->startIrLearn([clientSocket](IrRawResponse *response) -> esp_err_t {
+                    if (response) {
+                        char *sendir = raw_timings_to_gc_sendir(response->timings_us, response->timings_len,
+                                                                response->frequency, "1:1", 1);
+                        if (sendir) {
+                            send_string_to_socket(clientSocket, sendir);
+                            free(sendir);
+                        }
+                        free(response->timings_us);
+                        delete response;
+                    }
+                    return ESP_OK;
+                });
+                if (!send_string_to_socket(client->socket, "IR Learner Enabled\r")) {
+                    should_break = true;
+                    break;
+                }
+            } else if (strcmp(req.command, "stop_IRL") == 0) {
+                client->irService->stopIrLearn();
+                if (!send_string_to_socket(client->socket, "IR Learner Disabled\r")) {
+                    should_break = true;
+                    break;
+                }
+            } else {
+                // Command unrecognized
+                char buf[17];
+                snprintf(buf, sizeof(buf), "ERR_%d:%d,001\r", req.module, req.port);
+                if (!send_string_to_socket(client->socket, buf)) {
+                    should_break = true;
+                    break;
+                }
+            }
+        }
+
+        if (should_break) {
+            break;
+        }
+
+        // Move remaining data to the beginning of the buffer
+        int remaining = (rx_buffer + total_len) - ptr;
+        if (remaining > 0) {
+            memmove(rx_buffer, ptr, remaining);
+            total_len = remaining;
+        } else {
+            total_len = 0;
+        }
+
+        if (total_len == sizeof(rx_buffer) - 1) {
             // error: code too long / no carriage return
             const char *msg = (strncmp(rx_buffer, "sendir,", 7) == 0) ? "ERR 020\r" : "ERR 016\r";
             if (!send_string_to_socket(client->socket, msg)) {
                 break;
             }
-            continue;
-        }
-        *end = 0;
-
-        // find start of message, skip all non graphical representation characters
-        // https://en.cppreference.com/w/c/string/byte/isgraph
-        const char *start = rx_buffer;
-        while (start != end && !isgraph(*start)) {
-            start++;
-        }
-        if (start == end) {
-            // ignore, no error (as iTach device)
-            continue;
-        }
-
-        GCMsg req;
-        auto  result = parseGcRequest(rx_buffer, &req);
-        if (result) {
-            char buf[16];
-            // global cache iTach error code
-            snprintf(buf, sizeof(buf), "ERR_1:1,%03d\r", result);
-            if (!send_string_to_socket(client->socket, buf)) {
-                break;
-            }
-            continue;
-        }
-
-        if (strcmp(req.command, "sendir") == 0) {
-            int16_t  clientId = IR_CLIENT_GC;
-            uint32_t msgId = atoi(req.param);  // this _should_ point to ID
-            auto     result = client->irService->sendGlobalCache(clientId, msgId, rx_buffer, client->socket);
-            ESP_LOGD(TAG_GC, "[%d] sendGlobalCache result: %d", client->socket, result);
-
-            char        buf[17];
-            const char *msg = nullptr;
-            if (result == 0 || result == 200) {
-                // OK, async callback over the passed socket (code 200 shouldn't be used anymore)
-            } else if (result == 202) {
-                // accepted IR repeat. Original iTach device doesn't send a reply, so we do the same!
-            } else if (result > 0 && result < 100) {
-                // global cache iTach error code
-                snprintf(buf, sizeof(buf), "ERR_%d:%d,%03d\r", req.module, req.port, result);
-                msg = buf;
-            } else if (result == 500) {
-                // invalid parameter
-                snprintf(buf, sizeof(buf), "ERR_%d:%d,023\r", req.module, req.port);
-                msg = buf;
-            } else if (result == 429 || result == 503) {
-                msg = "busyir\r";
-            } else {
-                // invalid command (unknown)
-                snprintf(buf, sizeof(buf), "ERR_%d:%d,001\r", req.module, req.port);
-                msg = buf;
-            }
-
-            if (msg && !send_string_to_socket(client->socket, msg)) {
-                break;
-            }
-        } else if (strcmp(req.command, "stopir") == 0) {
-            client->irService->stopSend();
-            if (!send_string_to_socket(client->socket, rx_buffer)) {
-                break;
-            }
-        } else if (strcmp(req.command, "getdevices") == 0) {
-            if (!send_string_to_socket(client->socket, "device,0,0 ETHERNET\r")) {
-                break;
-            }
-            int  ports = 4;
-            char msg[64];
-            snprintf(msg, sizeof(msg), "device,0,0 WIFI\rdevice,1,%d IR\rendlistdevices\r", ports);
-            if (!send_string_to_socket(client->socket, msg)) {
-                break;
-            }
-        } else if (strcmp(req.command, "getversion") == 0) {
-            // GlobalCache iHelp doesn't like dots in version string, or device doesn't show up!
-            char version[30];
-            snprintf(version, sizeof(version), "%s\r", DOCK_VERSION[0] == 'v' ? DOCK_VERSION + 1 : DOCK_VERSION);
-            replacechar(version, '.', '-');
-            replacechar(version, '+', '-');
-            if (!send_string_to_socket(client->socket, version)) {
-                break;
-            }
-        } else if (strcmp(req.command, "getmac") == 0) {
-            // command discovered with iHelp
-            char mac[30];
-            snprintf(mac, sizeof(mac), "MACaddress,%s\r", client->mac);
-            if (!send_string_to_socket(client->socket, mac)) {
-                break;
-            }
-        } else if (strcmp(req.command, "blink") == 0) {
-            ESP_ERROR_CHECK_WITHOUT_ABORT(
-                esp_event_post(UC_DOCK_EVENTS, UC_ACTION_IDENTIFY, NULL, 0, pdMS_TO_TICKS(200)));
-        } else if (strcmp(req.command, "get_IRL") == 0) {
-            client->irService->startIrLearn();
-            if (!send_string_to_socket(client->socket, "IR Learner Enabled")) {
-                break;
-            }
-        } else if (strcmp(req.command, "stop_IRL") == 0) {
-            client->irService->stopIrLearn();
-            if (!send_string_to_socket(client->socket, "IR Learner Disabled")) {
-                break;
-            }
-        } else {
-            // Command unrecognized
-            char buf[17];
-            snprintf(buf, sizeof(buf), "ERR_%d:%d,001\r", req.module, req.port);
-            if (!send_string_to_socket(client->socket, buf)) {
-                break;
-            }
+            total_len = 0;
         }
     }
 
@@ -378,6 +431,11 @@ void GlobalCacheServer::socket_task(void *param) {
         ESP_LOGE(TAG_GC, "[%d] Error occurred during receiving: errno %d", client->socket, errno);
     } else if (len == 0) {
         ESP_LOGI(TAG_GC, "[%d] Connection closed", client->socket);
+    }
+
+    // Stop IR learning if active (clears callback override)
+    if (client->irService->isIrLearning()) {
+        client->irService->stopIrLearn();
     }
 
     shutdown(client->socket, 0);
@@ -432,8 +490,11 @@ void GlobalCacheServer::beacon_task(void *param) {
     snprintf(version, sizeof(version), "%s", DOCK_VERSION[0] == 'v' ? DOCK_VERSION + 1 : DOCK_VERSION);
     replacechar(version, '.', '-');
     replacechar(version, '+', '-');
-    char uuid[30];
-    snprintf(uuid, sizeof(uuid), "UnfoldedCircle_%s", gc->m_config->getHostName() + 9);
+    char    uuid[30];
+    uint8_t mac[6];
+    esp_read_mac(mac, ESP_MAC_WIFI_STA);
+    snprintf(uuid, sizeof(uuid), "UnfoldedCircle_%02X%02X%02X%02X%02X%02X", mac[0], mac[1], mac[2], mac[3], mac[4],
+             mac[5]);
 
     esp_netif_ip_info_t ipInfo;
 

--- a/components/infrared/ir_codes.cpp
+++ b/components/infrared/ir_codes.cpp
@@ -10,6 +10,8 @@
 
 #include "esp_log.h"
 
+#include "ir_Panasonic.h"
+
 static const char *TAG = "IR";
 
 uint32_t parseUint32(const char *number, int *error, int base) {
@@ -257,4 +259,29 @@ uint16_t *globalCacheBufferToArray(const char *msg, uint16_t *codeCount, int *me
 
     *codeCount = codeIndex;
     return codeArray;
+}
+
+uint32_t frequencyFromProtocol(int16_t decode_type, uint16_t bits) {
+    switch (decode_type) {
+        case decode_type_t::DAIKIN2:
+        case decode_type_t::PANASONIC:
+            return kPanasonicFreq;
+        case decode_type_t::DENON:
+            return bits >= kPanasonicBits ? kPanasonicFreq : 38000;
+        case decode_type_t::RC5:
+        case decode_type_t::RC5X:
+        case decode_type_t::RC6:
+        case decode_type_t::RCMM:
+        case decode_type_t::TROTEC:
+            return 36000;
+        case decode_type_t::PIONEER:
+        case decode_type_t::SONY:
+            return 40000;
+        case decode_type_t::DISH:
+            return 57600;
+        case decode_type_t::LUTRON:
+            return 40000;
+        default:
+            return 38000;
+    }
 }

--- a/components/infrared/ir_codes.h
+++ b/components/infrared/ir_codes.h
@@ -63,3 +63,7 @@ uint16_t countValuesInCStr(const char *str, char sep);
 uint16_t *prontoBufferToArray(const char *msg, char separator, uint16_t *codeCount, int *memError = NULL);
 
 uint16_t *globalCacheBufferToArray(const char *msg, uint16_t *codeCount, int *memError = NULL);
+
+/// Return the frequency of a given protocol.
+/// Values have been pulled out of the individual IR decoders.
+uint32_t frequencyFromProtocol(int16_t decode_type, uint16_t bits);

--- a/components/infrared/service_ir.cpp
+++ b/components/infrared/service_ir.cpp
@@ -682,7 +682,7 @@ static IrRawResponse *serialize_raw_response(const decode_results *results) {
     IrRawResponse *response = new IrRawResponse();
     // Default carrier frequency. Not possible to get modulation frequency with IRrecv and a TSOP‑style demodulator.
     // TODO use IR_RECEIVE_ANALOG and custom logic for raw learning.
-    response->frequency = 38000;
+    response->frequency = frequencyFromProtocol(results->decode_type, results->bits);
     response->timings_len = getCorrectedRawLength(results);
     response->timings_us = resultToRawArray(results);
 

--- a/components/infrared/service_ir.cpp
+++ b/components/infrared/service_ir.cpp
@@ -64,6 +64,7 @@ void InfraredService::init(port_map_t ports, uint16_t sendCore, uint16_t sendPri
 
     ports_ = ports;
     m_responseCallback = responseCallback;
+    m_callbackOverride = nullptr;
 
     m_queue = xQueueCreate(1, sizeof(struct IRSendMessage *));
     if (m_queue == nullptr) {
@@ -122,6 +123,7 @@ void InfraredService::setIrLearnPriority(uint16_t priority) {
 
 void InfraredService::startIrLearn(IRFormat irFormat) {
     // Note: UC_EVENT_IR_LEARNING_START event is sent when the learning loop starts
+    m_callbackOverride = nullptr;
     if (m_eventgroup) {
         EventBits_t uxBitsToSet = IR_LEARNING_BIT;
         if (irFormat == IRFormat::RAW) {
@@ -132,11 +134,19 @@ void InfraredService::startIrLearn(IRFormat irFormat) {
     }
 }
 
+void InfraredService::startIrLearn(IrRawResponseCallback callbackOverride) {
+    if (m_eventgroup) {
+        m_callbackOverride = callbackOverride;
+        xEventGroupSetBits(m_eventgroup, IR_LEARNING_BIT | IR_LEARNING_RAW_BIT);
+    }
+}
+
 void InfraredService::stopIrLearn() {
     // Note: UC_EVENT_IR_LEARNING_STOP event is sent after the learning loop stops
     if (m_eventgroup) {
         xEventGroupClearBits(m_eventgroup, IR_LEARNING_BIT | IR_LEARNING_RAW_BIT);
     }
+    m_callbackOverride = nullptr;
 }
 
 bool InfraredService::isIrLearning() {
@@ -657,6 +667,28 @@ static std::string serialize_raw_optimized(const decode_results *results, const 
     return buf;
 }
 
+/// Serialize raw IR timings into an IrRawResponse struct.
+/// Parameters:
+///   results - decoded IR results from IRrecv
+///
+/// Returns heap-allocated IrRawResponse with frequency (default 38000 Hz) and timing values in microseconds.
+/// Caller must free().
+/// Returns NULL on invalid input.
+static IrRawResponse *serialize_raw_response(const decode_results *results) {
+    if (results->rawlen == 0) {
+        return NULL;
+    }
+
+    IrRawResponse *response = new IrRawResponse();
+    // Default carrier frequency. Not possible to get modulation frequency with IRrecv and a TSOP‑style demodulator.
+    // TODO use IR_RECEIVE_ANALOG and custom logic for raw learning.
+    response->frequency = 38000;
+    response->timings_len = getCorrectedRawLength(results);
+    response->timings_us = resultToRawArray(results);
+
+    return response;
+}
+
 void InfraredService::learn_ir_f(void *param) {
     if (param == nullptr) {
         ESP_LOGE(irLogLearn, "BUG: missing learn_ir_f param");
@@ -760,6 +792,15 @@ void InfraredService::learn_ir_f(void *param) {
                 event_ir.command = results.command;
                 ESP_ERROR_CHECK_WITHOUT_ABORT(esp_event_post(UC_DOCK_EVENTS, UC_EVENT_IR_LEARNING_OK, &event_ir,
                                                              sizeof(event_ir), pdMS_TO_TICKS(500)));
+            }
+
+            if (ir->m_callbackOverride) {
+                struct IrRawResponse *response = serialize_raw_response(&results);
+                if (response) {
+                    ir->m_callbackOverride(response);
+                }
+
+                continue;
             }
 
             struct IrResponse *response = new IrResponse();

--- a/components/infrared/service_ir.h
+++ b/components/infrared/service_ir.h
@@ -22,17 +22,22 @@ struct IrResponse {
     std::string message;
 };
 
-typedef std::function<esp_err_t(IrResponse *response)> IrResponseCallback;
+struct IrRawResponse {
+    uint32_t  frequency;
+    uint16_t  timings_len;
+    uint16_t *timings_us;
+};
+
+typedef std::function<esp_err_t(IrResponse *response)>    IrResponseCallback;
+typedef std::function<esp_err_t(IrRawResponse *response)> IrRawResponseCallback;
 
 class InfraredService {
  public:
     static InfraredService &getInstance();
 
-    /**
-     * Initialize and start infrared processing.
-     *
-     * This must be called **once** at startup before using `send` or `startIrLearn`.
-     */
+    /// @brief Initialize and start infrared processing.
+    ///
+    /// This must be called **once** at startup before using `send` or `startIrLearn`.
     void init(port_map_t ports, uint16_t sendCore, uint16_t sendPriority, uint16_t learnCore, uint16_t learnPriority,
               IrResponseCallback responseCallback);
 
@@ -41,34 +46,40 @@ class InfraredService {
 
     uint16_t sendGlobalCache(int16_t clientId, uint32_t msgId, const char *sendir, int socket = 0);
 
-    /**
-     * Asynchronously send an IR code on the 2nd core.
-     *
-     * If there's still an IR code being sent, error 429 (too many requests) is returned.
-     *
-     * @param clientId the WebSocket client identifier to associate the response message.
-     * @param msgId the client send request message identifier to associate the response message with.
-     * @param code  IR code to send, either PRONTO or HEX (UnfoldedCircle) format.
-     * @param format IR code format: "pronto" or "hex".
-     * @param repeat IR repeat count.
-     * @param hold   IR send time in milliseconds. The repeat parameter is ignored if hold > 0.
-     * @param internal_side Send IR signal on internal LEDs.
-     * @param internal_top Send IR signal on internal top LED.
-     * @param external1 Send IR signal on external 1 emitter port.
-     * @param external2 Send IR signal on external 2 emitter port.
-     * @param gcSocket Optional TCP socket if message was received from the GlobalCache TCP server.
-     *
-     * @return 0: asynchronous reply from the the IR send task: don't send a reply to the WS client.
-     * @return 202: extended an IR repeat sequence.
-     * @return otherwise: status code to return to the WS client.
-     */
+    /// @brief Asynchronously send an IR code on the 2nd core.
+    ///
+    /// If there's still an IR code being sent, error 429 (too many requests) is returned.
+    ///
+    /// @param clientId the WebSocket client identifier to associate the response message.
+    /// @param msgId the client send request message identifier to associate the response message with.
+    /// @param code  IR code to send, either PRONTO or HEX (UnfoldedCircle) format.
+    /// @param format IR code format: "pronto" or "hex".
+    /// @param repeat IR repeat count.
+    /// @param hold   IR send time in milliseconds. The repeat parameter is ignored if hold > 0.
+    /// @param internal_side Send IR signal on internal LEDs.
+    /// @param internal_top Send IR signal on internal top LED.
+    /// @param external1 Send IR signal on external 1 emitter port.
+    /// @param external2 Send IR signal on external 2 emitter port.
+    /// @param gcSocket Optional TCP socket if message was received from the GlobalCache TCP server.
+    ///
+    /// @return 0: asynchronous reply from the the IR send task: don't send a reply to the WS client.
+    /// @return 202: extended an IR repeat sequence.
+    /// @return otherwise: status code to return to the WS client.
     uint16_t send(int16_t clientId, uint32_t msgId, const std::string &code, const std::string &format, uint16_t repeat,
                   uint16_t hold, bool internal_side, bool internal_top, bool external1, bool external2,
                   int gcSocket = 0);
 
     void stopSend();
 
+    /// @brief Start IR learning mode
+    /// @param irFormat IR format to return. Only `UNFOLDED_CIRCLE` and `RAW` are supported.
     void startIrLearn(IRFormat irFormat = IRFormat::UNFOLDED_CIRCLE);
+
+    /// @brief Start exclusive RAW IR learning mode
+    /// @param callbackOverride Only send learned codes to this callback.
+    void startIrLearn(IrRawResponseCallback callbackOverride);
+
+    /// @brief Stop IR learning
     void stopIrLearn();
     bool isIrLearning();
 
@@ -102,7 +113,8 @@ class InfraredService {
 
     port_map_t ports_;
 
-    IrResponseCallback m_responseCallback;
+    IrResponseCallback    m_responseCallback;
+    IrRawResponseCallback m_callbackOverride;
 };
 
 extern InfraredService &irService;

--- a/test/infrared/test_globalcache.cpp
+++ b/test/infrared/test_globalcache.cpp
@@ -9,9 +9,9 @@
 TEST(GlobalCacheTest, parseGcRequest_nullInput) {
     const char *request = "blink";
     GCMsg       msg;
-    EXPECT_EQ(0, parseGcRequest(request, nullptr));
-    EXPECT_EQ(0, parseGcRequest(nullptr, &msg));
-    EXPECT_EQ(0, parseGcRequest(nullptr, nullptr));
+    EXPECT_EQ(17, parseGcRequest(request, nullptr));
+    EXPECT_EQ(17, parseGcRequest(nullptr, &msg));
+    EXPECT_EQ(17, parseGcRequest(nullptr, nullptr));
 }
 
 TEST(GlobalCacheTest, parseGcRequest_emptyInput) {
@@ -117,4 +117,380 @@ TEST(GlobalCacheTest, parseGcRequest_invalidPort) {
     EXPECT_EQ(3, parseGcRequest("stopir,1:,2", &msg));
     EXPECT_EQ(3, parseGcRequest("stopir,1:a", &msg));
     EXPECT_EQ(3, parseGcRequest("stopir,1:a,2", &msg));
+}
+
+class RawTimingsToGcSendirTest : public ::testing::Test {
+ protected:
+    void TearDown() override {
+        if (result_ != nullptr) {
+            free(result_);
+            result_ = nullptr;
+        }
+    }
+
+    char *result_ = nullptr;
+};
+
+// --- NULL and invalid input ---
+
+TEST_F(RawTimingsToGcSendirTest, NullTimingsReturnsNull) {
+    result_ = raw_timings_to_gc_sendir(nullptr, 4, 38000, "1:1", 1);
+    EXPECT_EQ(result_, nullptr);
+}
+
+TEST_F(RawTimingsToGcSendirTest, ZeroLengthReturnsNull) {
+    uint16_t timings[] = {100, 200};
+    result_ = raw_timings_to_gc_sendir(timings, 0, 38000, "1:1", 1);
+    EXPECT_EQ(result_, nullptr);
+}
+
+TEST_F(RawTimingsToGcSendirTest, ZeroFrequencyReturnsNull) {
+    uint16_t timings[] = {100, 200};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 0, "1:1", 1);
+    EXPECT_EQ(result_, nullptr);
+}
+
+TEST_F(RawTimingsToGcSendirTest, NullConnectorReturnsNull) {
+    uint16_t timings[] = {100, 200};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 38000, nullptr, 1);
+    EXPECT_EQ(result_, nullptr);
+}
+
+// --- Frequency range validation ---
+
+TEST_F(RawTimingsToGcSendirTest, FrequencyBelowMinReturnsNull) {
+    uint16_t timings[] = {100, 200};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 14999, "1:1", 1);
+    EXPECT_EQ(result_, nullptr);
+}
+
+TEST_F(RawTimingsToGcSendirTest, FrequencyAtMin) {
+    uint16_t timings[] = {100, 200};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 15000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_TRUE(strstr(result_, "sendir,1:1,1,15000,1,1,") != nullptr);
+}
+
+TEST_F(RawTimingsToGcSendirTest, FrequencyAtMax) {
+    uint16_t timings[] = {100, 200};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 500000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_TRUE(strstr(result_, "sendir,1:1,1,500000,1,1,") != nullptr);
+}
+
+TEST_F(RawTimingsToGcSendirTest, FrequencyAboveMaxReturnsNull) {
+    uint16_t timings[] = {100, 200};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 500001, "1:1", 1);
+    EXPECT_EQ(result_, nullptr);
+}
+
+// --- Basic conversion: even count ---
+
+TEST_F(RawTimingsToGcSendirTest, SimplePair38kHz) {
+    // 9000 µs at 38kHz: round(9000 * 38000 / 1000000) = round(342.0) = 342
+    // 4500 µs at 38kHz: round(4500 * 38000 / 1000000) = round(171.0) = 171
+    uint16_t timings[] = {9000, 4500};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,342,171\r");
+}
+
+TEST_F(RawTimingsToGcSendirTest, MultiplePairs38kHz) {
+    // 560 µs: round(560 * 38000 / 1000000) = round(21.28) = 21
+    // 1690 µs: round(1690 * 38000 / 1000000) = round(64.22) = 64
+    uint16_t timings[] = {9000, 4500, 560, 1690};
+    result_ = raw_timings_to_gc_sendir(timings, 4, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,342,171,21,64\r");
+}
+
+TEST_F(RawTimingsToGcSendirTest, SimplePair40kHz) {
+    // 9000 µs at 40kHz: round(9000 * 40000 / 1000000) = round(360) = 360
+    // 4500 µs at 40kHz: round(4500 * 40000 / 1000000) = round(180) = 180
+    uint16_t timings[] = {9000, 4500};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 40000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,40000,1,1,360,180\r");
+}
+
+// --- Odd count: last value duplicated as OFF ---
+
+TEST_F(RawTimingsToGcSendirTest, OddCountSingleValue) {
+    // 560 µs at 38kHz = 21 periods. Duplicated as OFF.
+    uint16_t timings[] = {560};
+    result_ = raw_timings_to_gc_sendir(timings, 1, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,21,21\r");
+}
+
+TEST_F(RawTimingsToGcSendirTest, OddCountThreeValues) {
+    uint16_t timings[] = {9000, 4500, 560};
+    result_ = raw_timings_to_gc_sendir(timings, 3, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,342,171,21,21\r");
+}
+
+TEST_F(RawTimingsToGcSendirTest, OddCountFiveValues) {
+    uint16_t timings[] = {9000, 4500, 560, 1690, 560};
+    result_ = raw_timings_to_gc_sendir(timings, 5, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,342,171,21,64,21,21\r");
+}
+
+// --- Overflow handling: single overflow ---
+
+TEST_F(RawTimingsToGcSendirTest, OverflowSingleOnMark) {
+    // 70000 µs mark encoded as: [65535, 0, 4465, <space>]
+    // Logical: 65535 + 4465 = 70000 µs
+    // At 38kHz: round(70000 * 38000 / 1000000) = round(2660) = 2660
+    uint16_t timings[] = {65535, 0, 4465, 4500};
+    result_ = raw_timings_to_gc_sendir(timings, 4, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,2660,171\r");
+}
+
+TEST_F(RawTimingsToGcSendirTest, OverflowSingleOnSpace) {
+    // 9000 µs mark, then 70000 µs space encoded as: [9000, 65535, 0, 4465]
+    // But wait: overflow in space position means:
+    // Index 0: 9000 (mark)
+    // Index 1: 65535 (space start)
+    // Index 2: 0 (skip mark)
+    // Index 3: 4465 (space continuation)
+    // Logical: mark=9000, space=65535+4465=70000
+    uint16_t timings[] = {9000, 65535, 0, 4465};
+    result_ = raw_timings_to_gc_sendir(timings, 4, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,342,2660\r");
+}
+
+// --- Overflow handling: double overflow ---
+
+TEST_F(RawTimingsToGcSendirTest, OverflowDoubleOnMark) {
+    // 140000 µs mark: [65535, 0, 65535, 0, 8930, <space>]
+    // Logical: 65535 + 65535 + 8930 = 140000 µs
+    // At 38kHz: round(140000 * 38000 / 1000000) = round(5320) = 5320
+    uint16_t timings[] = {65535, 0, 65535, 0, 8930, 4500};
+    result_ = raw_timings_to_gc_sendir(timings, 6, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,5320,171\r");
+}
+
+// --- Overflow handling: overflow followed by normal pairs ---
+
+TEST_F(RawTimingsToGcSendirTest, OverflowFollowedByNormalPairs) {
+    // Overflow mark + normal space, then normal pair
+    uint16_t timings[] = {65535, 0, 4465, 4500, 560, 1690};
+    result_ = raw_timings_to_gc_sendir(timings, 6, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,2660,171,21,64\r");
+}
+
+TEST_F(RawTimingsToGcSendirTest, NormalPairsFollowedByOverflow) {
+    uint16_t timings[] = {560, 1690, 65535, 0, 4465, 4500};
+    result_ = raw_timings_to_gc_sendir(timings, 6, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,21,64,2660,171\r");
+}
+
+// --- Overflow with odd logical count ---
+
+TEST_F(RawTimingsToGcSendirTest, OverflowResultingInOddLogicalCount) {
+    // Overflow mark + space + normal mark = 3 logical values (odd)
+    uint16_t timings[] = {65535, 0, 4465, 4500, 560};
+    result_ = raw_timings_to_gc_sendir(timings, 5, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,2660,171,21,21\r");
+}
+
+// --- Minimum value clamping ---
+
+TEST_F(RawTimingsToGcSendirTest, VerySmallValueClampedToOne) {
+    // 1 µs at 15000 Hz: round(1 * 15000 / 1000000) = round(0.015) = 0 → clamped to 1
+    uint16_t timings[] = {1, 1};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 15000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,15000,1,1,1,1\r");
+}
+
+TEST_F(RawTimingsToGcSendirTest, ZeroTimingClampedToOne) {
+    // A non-overflow 0 at the start should result in period=0 → clamped to 1
+    // Note: a 0 at position 0 is not an overflow skip, it's just a zero-duration pulse.
+    // Actually, a 0 at an even index (mark) that is NOT preceded by a value
+    // is a real 0 value, not a skip.
+    // Hmm - this depends on interpretation. The skip logic triggers when
+    // timings_us[i] == 0 and i+1 < timings_len, meaning the NEXT value continues.
+    // At index 0: 0 is just a timing value.
+    uint16_t timings[] = {0, 200};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    // 0 µs → 0 periods → clamped to 1
+    // 200 µs → round(200 * 38000 / 1000000) = round(7.6) = 8
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,1,8\r");
+}
+
+// --- Connector address variants ---
+
+TEST_F(RawTimingsToGcSendirTest, ConnectorAddress1_2) {
+    uint16_t timings[] = {560, 1690};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 38000, "1:2", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_TRUE(strstr(result_, "sendir,1:2,") != nullptr);
+}
+
+TEST_F(RawTimingsToGcSendirTest, ConnectorAddress1_3) {
+    uint16_t timings[] = {560, 1690};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 38000, "1:3", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_TRUE(strstr(result_, "sendir,1:3,") != nullptr);
+}
+
+// --- ID variants ---
+
+TEST_F(RawTimingsToGcSendirTest, IdZero) {
+    uint16_t timings[] = {560, 1690};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 38000, "1:1", 0);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,0,38000,1,1,21,64\r");
+}
+
+TEST_F(RawTimingsToGcSendirTest, IdMax) {
+    uint16_t timings[] = {560, 1690};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 38000, "1:1", 65535);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_TRUE(strstr(result_, "sendir,1:1,65535,38000,1,1,") != nullptr);
+}
+
+// --- High frequency conversion ---
+
+TEST_F(RawTimingsToGcSendirTest, HighFrequency455kHz) {
+    // 100 µs at 455000 Hz: round(100 * 455000 / 1000000) = round(45.5) = 46
+    // 200 µs at 455000 Hz: round(200 * 455000 / 1000000) = round(91.0) = 91
+    uint16_t timings[] = {100, 200};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 455000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,455000,1,1,46,91\r");
+}
+
+// --- Typical NEC protocol pattern ---
+
+TEST_F(RawTimingsToGcSendirTest, TypicalNecLeaderAndBits) {
+    // NEC leader: 9000 µs mark, 4500 µs space
+    // Bit 1: 560 µs mark, 1690 µs space
+    // Bit 0: 560 µs mark, 560 µs space
+    // Final: 560 µs mark, 560 µs space (stop bit)
+    uint16_t timings[] = {9000, 4500, 560, 1690, 560, 560, 560, 560};
+    result_ = raw_timings_to_gc_sendir(timings, 8, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,342,171,21,64,21,21,21,21\r");
+}
+
+// --- UINT16_MAX as a normal timing (no overflow, no skip follows) ---
+
+TEST_F(RawTimingsToGcSendirTest, Uint16MaxAsNormalTiming) {
+    // 65535 µs at 38kHz: round(65535 * 38000 / 1000000) = round(2490.33) = 2490
+    // Next value is NOT 0, so no overflow accumulation.
+    uint16_t timings[] = {65535, 65535};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,2490,2490\r");
+}
+
+// --- Overflow: 0 only triggers skip if next element exists ---
+
+TEST_F(RawTimingsToGcSendirTest, ZeroAsLastElementIsNotSkip) {
+    // [560, 0] - the 0 is at position 1 (last element).
+    // The skip condition requires i+1 < timings_len, which is false for last element.
+    // So 0 is a normal space value → clamped to 1 period.
+    uint16_t timings[] = {560, 0};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,21,1\r");
+}
+
+TEST_F(RawTimingsToGcSendirTest, ZeroAsSecondToLastIsNotSkip) {
+    // [560, 1690, 0] - 3 elements.
+    // Index 2: value is 0. Check: i+1 (=3) < timings_len (=3)? No → not a skip.
+    // So it's a logical pulse with 0 µs → clamped to 1.
+    // Logical count = 3 (odd) → last value (1) duplicated.
+    uint16_t timings[] = {560, 1690, 0};
+    result_ = raw_timings_to_gc_sendir(timings, 3, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,21,64,1,1\r");
+}
+
+// --- Multiple consecutive overflows in different positions ---
+
+TEST_F(RawTimingsToGcSendirTest, OverflowMarkThenOverflowSpace) {
+    // Mark overflow: [65535, 0, 4465] = 70000 µs mark
+    // Space overflow: [65535, 0, 4465] = 70000 µs space
+    // At 38kHz: round(70000 * 38000 / 1000000) = 2660
+    uint16_t timings[] = {65535, 0, 4465, 65535, 0, 4465};
+    result_ = raw_timings_to_gc_sendir(timings, 6, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,2660,2660\r");
+}
+
+// --- Rounding behavior ---
+
+TEST_F(RawTimingsToGcSendirTest, RoundingDown) {
+    // 550 µs at 38kHz: round(550 * 38000 / 1000000) = round(20.9) = 21
+    uint16_t timings[] = {550, 550};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,21,21\r");
+}
+
+TEST_F(RawTimingsToGcSendirTest, RoundingUp) {
+    // 540 µs at 38kHz: round(540 * 38000 / 1000000) = round(20.52) = 21
+    // 530 µs at 38kHz: round(530 * 38000 / 1000000) = round(20.14) = 20
+    uint16_t timings[] = {540, 530};
+    result_ = raw_timings_to_gc_sendir(timings, 2, 38000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    EXPECT_STREQ(result_, "sendir,1:1,1,38000,1,1,21,20\r");
+}
+
+TEST_F(RawTimingsToGcSendirTest, ExactHalfRoundsUp) {
+    // Need a value where µs * freq / 1000000 = X.5
+    // At 40000 Hz, period = 25 µs. 37 µs → 37/25 = 1.48 → 1. Not .5.
+    // 25 µs * 2.5 = 62.5 µs → round(62.5 * 40000 / 1000000) = round(2.5) = 3 (banker's rounds to 2 in some impl.)
+    // Use a known case: 500 µs at 36000 Hz → round(500*36000/1000000) = round(18.0) = 18
+    // Better: 750 µs at 20000 Hz → round(750*20000/1000000) = round(15.0) = 15
+    // For exact .5: 25 µs at 20000 Hz → round(25*20000/1000000) = round(0.5) = 1 (round half up)
+    uint16_t timings[] = {25, 75};
+    // 25 µs at 20000 Hz: round(0.5) = 1 (with round() from cmath)
+    // 75 µs at 20000 Hz: round(1.5) = 2
+    result_ = raw_timings_to_gc_sendir(timings, 2, 20000, "1:1", 1);
+    ASSERT_NE(result_, nullptr);
+    // C round() rounds .5 away from zero → 1 and 2
+    EXPECT_STREQ(result_, "sendir,1:1,1,20000,1,1,1,2\r");
+}
+
+// --- Large realistic signal (even count, no overflow) ---
+
+TEST_F(RawTimingsToGcSendirTest, LargerSignalNoOverflow) {
+    // Simplified NEC-like: leader + 4 bit-pairs + stop
+    uint16_t timings[] = {
+        9000, 4500,  // leader
+        560,  1690,  // bit 1
+        560,  560,   // bit 0
+        560,  1690,  // bit 1
+        560,  560,   // bit 0
+        560,  40000  // stop (long space)
+    };
+    result_ = raw_timings_to_gc_sendir(timings, 12, 38000, "1:1", 42);
+    ASSERT_NE(result_, nullptr);
+    // Verify header
+    EXPECT_TRUE(strstr(result_, "sendir,1:1,42,38000,1,1,") != nullptr);
+    // Count commas to verify 12 values after header (6 fields in header + 12 data = 17 commas total)
+    int commas = 0;
+    for (char *p = result_; *p; p++) {
+        if (*p == ',') commas++;
+    }
+    // "sendir,1:1,42,38000,1,1,v1,v2,...,v12" → 5 header commas + 12 value commas - 1 = 16
+    // Actually: sendir | 1:1 | 42 | 38000 | 1 | 1 | v1 | v2 | ... | v12
+    //           ,       ,     ,     ,       ,   ,   ,    ,          ,
+    // = 5 (header seps) + 11 (between 12 values) = but values start with comma too
+    // Format: "sendir,1:1,42,38000,1,1,342,171,21,64,21,21,21,64,21,21,21,1520"
+    // Commas: let's just count = 17
+    EXPECT_EQ(commas, 17);
 }

--- a/test/mocks/IRremoteESP8266.h
+++ b/test/mocks/IRremoteESP8266.h
@@ -136,3 +136,5 @@ enum decode_type_t {
     // Add new entries before this one, and update it to point to the last entry.
     kLastDecodeType = YORK,
 };
+
+const uint16_t kPanasonicBits = 48;

--- a/test/mocks/ir_Panasonic.h
+++ b/test/mocks/ir_Panasonic.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "inttypes.h"
+
+const uint16_t kPanasonicFreq = 36700;


### PR DESCRIPTION
Use exclusive IR learning mode for API compatibility, stop learning if another command is received.

Important: the modulation frequency cannot be detected with the current implementation using the regular IR receiver. It's set to the decoded IR protocol frequency if available, otherwise to 38 kHz. This should work for the majority of IR commands.
A proper detection of the carrier frequency requires a custom IR learning implementation using the analog IR receiver.

Other changes:
- Improved request command parsing.
- Fix MAC address in beacon.
- Terminate all response messages with \r