### PR TITLE
refactor: only enable port1 RS232 mode if ROM boot log is muted

### DIFF
--- a/components/external_port/external_port.cpp
+++ b/components/external_port/external_port.cpp
@@ -423,7 +423,7 @@ bool ExternalPort::isModeSupported(ExtPortMode mode) {
         case TRIGGER_5V:
             return EXTERNAL_5V_TRIGGER_SUPPORT & (1 << (port_ - 1));
         case RS232:
-            return EXTERNAL_RS232_SUPPORT & (1 << (port_ - 1));
+            return board_port_supports_rs232(port_);
         default:
             return false;
     }

--- a/components/preferences/board.c
+++ b/components/preferences/board.c
@@ -8,11 +8,14 @@
 #include <soc/efuse_reg.h>
 
 #include "esp_efuse.h"
+#include "esp_efuse_table.h"
 #include "esp_log.h"
 
 #include "efuse_user.h"
 
 static int s_revision = 4;
+static int s_uart_print_ctrl_val = 0;
+
 // SPI chipselect for KSZ8851SNL ethernet ic, LOW -> enable communication to KSZ8851SNL
 // - r3: GPIO_NUM_6
 // - r4: GPIO_NUM_6
@@ -39,21 +42,45 @@ static adc_unit_t s_charging_current_adc_unit = ADC_UNIT_2;
 // - r6: ADC_CHANNEL_5
 static adc_channel_t s_charging_current_adc_ch = ADC_CHANNEL_3;
 
-int read_efuse_revision() {
+static const char *const TAG = "BOARD";
+
+static int read_efuse_revision() {
     char revision[4] = {0};
     esp_efuse_read_field_blob(ESP_EFUSE_USER_DATA_DOCK_HW_REV, &revision,
                               ESP_EFUSE_USER_DATA_DOCK_HW_REV[0]->bit_count);
     int rev = atoi(revision);
     if (rev < 3 || rev > 6) {
-        ESP_LOGW("BOARD",
+        ESP_LOGW(TAG,
                  "Invalid or no revision found in eFuse (%d): the device might not work properly! Using firmware "
                  "revision: %s",
                  rev, UCD_HW_REVISION_NAME);
         return atoi(UCD_HW_REVISION_NAME);
     }
 
-    ESP_LOGI("BOARD", "hw revision: %d, fw revision: %s", rev, UCD_HW_REVISION_NAME);
+    ESP_LOGI(TAG, "hw revision: %d, fw revision: %s", rev, UCD_HW_REVISION_NAME);
     return rev;
+}
+
+static uint8_t read_uart_print_ctrl_val(void) {
+    uint8_t uart_print_ctrl_val = 0;
+    uint8_t write_disabled = 0;
+
+    // UART_PRINT_CONTROL is 2 bits
+    esp_err_t err = esp_efuse_read_field_blob(ESP_EFUSE_UART_PRINT_CONTROL, &uart_print_ctrl_val, 2);
+    esp_err_t err_dis = esp_efuse_read_field_blob(ESP_EFUSE_WR_DIS_UART_PRINT_CONTROL, &write_disabled, 1);
+
+    if (err == ESP_OK && err_dis == ESP_OK) {
+        if (uart_print_ctrl_val != 3) {
+            ESP_LOGI(TAG,
+                     "ROM Boot log is enabled (%d, %d). Disabling port1 RS232 mode to prevent sending invalid data on "
+                     "startup",
+                     uart_print_ctrl_val, write_disabled);
+        }
+    } else {
+        ESP_LOGE(TAG, "Error reading eFuse configuration values: 0x%x, 0x%x", err, err_dis);
+    }
+
+    return uart_print_ctrl_val;
 }
 
 void board_init_revision(void) {
@@ -72,6 +99,8 @@ void board_init_revision(void) {
         // tied to IR side output on rev6+
         s_ir_send_pin_int_top = IR_SEND_PIN_INT_SIDE;
     }
+
+    s_uart_print_ctrl_val = read_uart_print_ctrl_val();
 }
 
 int board_get_revision(void) {
@@ -112,4 +141,16 @@ bool board_is_switch_ext_inverted(void) {
 
 gpio_mode_t board_switch_ext_gpio_mode(void) {
     return s_revision == 3 ? GPIO_MODE_OUTPUT_OD : GPIO_MODE_OUTPUT;
+}
+
+bool board_port_supports_rs232(uint8_t port) {
+    if (port < 1 || port > EXTERNAL_PORT_COUNT) {
+        return false;
+    }
+    // port1 shares UART output of ROM boot logs
+    if (port == 1) {
+        // only allow RS232 if ROM boot log is muted
+        return s_uart_print_ctrl_val == 3;
+    }
+    return true;
 }

--- a/components/preferences/board.h
+++ b/components/preferences/board.h
@@ -27,8 +27,6 @@
 #define EXTERNAL_IR_EMITTER_STEREO_SUPPORT (BIT0 | BIT1)
 // external port support for 5V triggers: bit flags, bit 0 == port 1, bit 1 == port 2 etc.
 #define EXTERNAL_5V_TRIGGER_SUPPORT (BIT0 | BIT1)
-// external port support for RS232: bit flags, bit 0 == port 1, bit 1 == port 2 etc.
-#define EXTERNAL_RS232_SUPPORT      (BIT0 | BIT1)
 
 #define CHARGE_LED_PWM        GPIO_NUM_40   // turn on leds in charging hole, OUTPUT, PULL DOWN to avoid false on
 // when ESP32 goes haywire it could light up LEDs, or when flashing
@@ -154,6 +152,9 @@ bool board_is_switch_ext_inverted(void);
 
 // GPIO output mode for SWITCH_EXT_1 & SWITCH_EXT_2: open drain or floating
 gpio_mode_t board_switch_ext_gpio_mode(void);
+
+// Check if output port supports RS232 mode
+bool board_port_supports_rs232(uint8_t port);
 
 #ifdef __cplusplus
 }

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -8,6 +8,11 @@ CONFIG_UCD_WEB_ENABLE_CORS=y
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ=240
 
+# disable uart0 log output in 2nd stage bootloader
+CONFIG_BOOTLOADER_LOG_LEVEL_NONE=y
+# only use usb uart
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+
 CONFIG_ESP_TASK_WDT_PANIC=y
 
 # default 2048 causes stack overflow and 3072 is still not enough. Likely because of timer usage in the state machines.


### PR DESCRIPTION
RS232 mode is limited to port 2 if ROM boot log is not muted.
Port 1 may send startup output that some connected RS232 devices could interpret as commands.