### PR TITLE
Release 0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ _Changes in the next release_
 
 ---
 
+## Release 0.10.3 - 2026-06-24
+
+### Fixed
+- Initialize RS232 port mode for proper RS232 signal levels ([#90](https://github.com/unfoldedcircle/ucd3-firmware/pull/90)).
+
+### Changed
+- Enhanced web UI RS232 console with line breaks and hex encoding ([#90](https://github.com/unfoldedcircle/ucd3-firmware/pull/90)).
+- Improved iTach API compatibility, command parsing and beacon data ([#91](https://github.com/unfoldedcircle/ucd3-firmware/pull/91)).
+- Web-UI: dynamically create supported port modes ([#92](https://github.com/unfoldedcircle/ucd3-firmware/pull/92)).
+- Only enable port 1 RS232 mode if the ROM boot log is muted. Port 1 may send startup output that some connected RS232 devices could interpret as commands ([#93](https://github.com/unfoldedcircle/ucd3-firmware/pull/93)).
+
+### Added
+- Support get_IRL iTach API command ([#91](https://github.com/unfoldedcircle/ucd3-firmware/pull/91)).
+
 ## Release 0.10.2 - 2026-06-18
 
 ### Fixed

--- a/doc/release/release-notes_de.md
+++ b/doc/release/release-notes_de.md
@@ -1,24 +1,26 @@
-## Release 0.10.2 - 2026-06-18
+## Release 0.10.3 - 2026-06-24
 Änderungen seit der letzten öffentlichen Version 0.8.2.
 
 ### Fehlerbehebungen
-- Verschiedene Stabilitätsverbesserungen und automatisches Trennen von hängenden Client-Verbindungen.
-- IR-Codes mit dem Datenwert 0 zulassen, z.B. die Ziffer "0" bei Philips-Fernsehern, die das RC6-Protokoll verwenden ([bug-tracker#721](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/721)).
-- Zuverlässigkeit von Ethernet verbessert ([#89](https://github.com/unfoldedcircle/ucd3-firmware/pull/89)).
-- Ändern der UART-Konfiguration ohne Neustart ermöglichen ([#84](https://github.com/unfoldedcircle/ucd3-firmware/pull/84)).
+- Allgemeine Stabilitätsverbesserungen und automatische Bereinigung hängender Client-Verbindungen.
+- Unterstützung für IR-Codes mit dem Datenwert `0` korrigiert, z. B. für die Ziffer „0“ bei Philips-Fernsehern mit RC6-Protokoll ([bug-tracker#721](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/721)).
+- Zuverlässigkeit der Ethernet-Verbindung verbessert ([#89](https://github.com/unfoldedcircle/ucd3-firmware/pull/89)).
+- UART-Einstellungen können jetzt ohne Neustart des Geräts geändert werden ([#84](https://github.com/unfoldedcircle/ucd3-firmware/pull/84)).
 
 ### Neue Funktionen
-- Integrierte Web-Management-Benutzeroberfläche ([#76](https://github.com/unfoldedcircle/ucd3-firmware/pull/76)).
-- Statische Netzwerkkonfiguration ([#81](https://github.com/unfoldedcircle/ucd3-firmware/pull/81)).
-- Unterstützung für Serielle Bridge (TCP/RS232) ([#72](https://github.com/unfoldedcircle/ucd3-firmware/pull/72)).
-- Neuer Log-Router für verbesserte Diagnose ([#77](https://github.com/unfoldedcircle/ucd3-firmware/pull/77)).
-- Unterstützung für RAW IR-Lernen und Senden ([#85](https://github.com/unfoldedcircle/ucd3-firmware/pull/85), [#87](https://github.com/unfoldedcircle/ucd3-firmware/pull/87)).
+- Integrierte Web-Verwaltungsoberfläche hinzugefügt, mit der das Gerät über einen Browser konfiguriert und verwaltet werden kann ([#76](https://github.com/unfoldedcircle/ucd3-firmware/pull/76)).
+- Unterstützung für statische Netzwerkkonfiguration hinzugefügt, um IP-Adressen manuell festlegen zu können ([#81](https://github.com/unfoldedcircle/ucd3-firmware/pull/81)).
+- RS232-Unterstützung mit optionaler TCP-Serial-Bridge hinzugefügt ([#72](https://github.com/unfoldedcircle/ucd3-firmware/pull/72)).
+  - Bei aktuellen Geräten ist der RS232-Modus auf Port 2 beschränkt. Port 1 kann beim Start Systemausgaben senden, die von manchen angeschlossenen RS232-Geräten als Befehle interpretiert werden könnten.
+  - UART-TTL-Adapter werden aufgrund unterschiedlicher Signalpegel nicht unterstützt.
+- Neuer Log-Router hinzugefügt, um Diagnose und Fehlersuche zu verbessern ([#77](https://github.com/unfoldedcircle/ucd3-firmware/pull/77)).
+- Unterstützung für das Lernen und Senden von RAW-IR-Befehlen hinzugefügt ([#85](https://github.com/unfoldedcircle/ucd3-firmware/pull/85), [#87](https://github.com/unfoldedcircle/ucd3-firmware/pull/87)).
 
 ### Geändert
-- Die am wenigsten aktive Client-Verbindung automatisch schließen, wenn keine Verbindungen mehr verfügbar sind ([#58](https://github.com/unfoldedcircle/ucd3-firmware/pull/58)).
-- Nicht authentifizierte Clients nach 30 Sekunden trennen ([#59](https://github.com/unfoldedcircle/ucd3-firmware/pull/59)).
+- Wenn die maximale Anzahl an Client-Verbindungen erreicht ist, wird jetzt automatisch die am wenigsten aktive Verbindung geschlossen, damit eine neue Verbindung hergestellt werden kann ([#58](https://github.com/unfoldedcircle/ucd3-firmware/pull/58)).
+- Nicht authentifizierte Clients werden jetzt nach 30 Sekunden getrennt ([#59](https://github.com/unfoldedcircle/ucd3-firmware/pull/59)).
 - Die maximale Anzahl an Client-Verbindungen wurde von 7 auf 18 erhöht ([#60](https://github.com/unfoldedcircle/ucd3-firmware/pull/60)).
-- Vereinheitlichung der Firmware-Revisionen 4 und 6 ([#66](https://github.com/unfoldedcircle/ucd3-firmware/pull/66)).
+- Unterstützung für die Firmware-Revisionen 4 und 6 vereinheitlicht ([#66](https://github.com/unfoldedcircle/ucd3-firmware/pull/66)).
 
 ## Beta Release 0.8.2 - 2026-02-14
 ### Fehlerbehebungen

--- a/doc/release/release-notes_en.md
+++ b/doc/release/release-notes_en.md
@@ -1,24 +1,26 @@
-## Release 0.10.2 - 2026-06-18
+## Release 0.10.3 - 2026-06-24
 Changes since the last public release, 0.8.2.
 
 ### Fixed
-- Various stability improvements and automatically releasing stuck client connections.
-- Allow IR codes with a data value of 0, such as the digit "0" on Philips TVs that use the RC6 protocol ([bug-tracker#721](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/721)).
-- Improved Ethernet reliability ([#89](https://github.com/unfoldedcircle/ucd3-firmware/pull/89)).
-- Allow changing UART configuration without a restart ([#84](https://github.com/unfoldedcircle/ucd3-firmware/pull/84)).
+- Improved overall stability and automatic cleanup of stuck client connections.
+- Fixed support for IR codes with a data value of `0`, such as the digit “0” on Philips TVs using the RC6 protocol ([bug-tracker#721](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/721)).
+- Improved Ethernet connection reliability ([#89](https://github.com/unfoldedcircle/ucd3-firmware/pull/89)).
+- UART settings can now be changed without restarting the Dock ([#84](https://github.com/unfoldedcircle/ucd3-firmware/pull/84)).
 
 ### Added
-- Embedded web management UI ([#76](https://github.com/unfoldedcircle/ucd3-firmware/pull/76)).
-- Static network configuration ([#81](https://github.com/unfoldedcircle/ucd3-firmware/pull/81)).
-- Serial bridge (TCP/RS232) support ([#72](https://github.com/unfoldedcircle/ucd3-firmware/pull/72)).
-- New log router for improved diagnostics ([#77](https://github.com/unfoldedcircle/ucd3-firmware/pull/77)).
-- Add RAW IR-learning and sending support ([#85](https://github.com/unfoldedcircle/ucd3-firmware/pull/85), [#87](https://github.com/unfoldedcircle/ucd3-firmware/pull/87)).
+- Added an embedded web management interface for configuring and managing the Dock from a browser ([#76](https://github.com/unfoldedcircle/ucd3-firmware/pull/76)).
+- Added support for static network configuration, allowing manual IP address settings ([#81](https://github.com/unfoldedcircle/ucd3-firmware/pull/81)).
+- Added RS232 support with an optional TCP serial bridge ([#72](https://github.com/unfoldedcircle/ucd3-firmware/pull/72)).
+  - On current devices, RS232 mode is limited to port 2. Port 1 may send startup output that some connected RS232 devices could interpret as commands.
+  - UART TTL adapters are not supported because they use different signal levels.
+- Added a new log router to improve diagnostics and troubleshooting ([#77](https://github.com/unfoldedcircle/ucd3-firmware/pull/77)).
+- Added support for learning and sending RAW IR commands ([#85](https://github.com/unfoldedcircle/ucd3-firmware/pull/85), [#87](https://github.com/unfoldedcircle/ucd3-firmware/pull/87)).
 
 ### Changed
-- Automatically close the least active client connection if no connections are available anymore ([#58](https://github.com/unfoldedcircle/ucd3-firmware/pull/58)).
-- Disconnect unauthenticated clients after 30s ([#59](https://github.com/unfoldedcircle/ucd3-firmware/pull/59)).
-- Increased max client connections from 7 to 18 ([#60](https://github.com/unfoldedcircle/ucd3-firmware/pull/60)).
-- Unify firmware revisions 4 and 6 ([#66](https://github.com/unfoldedcircle/ucd3-firmware/pull/66)).
+- If the maximum number of client connections is reached, the least active connection is now closed automatically to allow a new connection ([#58](https://github.com/unfoldedcircle/ucd3-firmware/pull/58)).
+- Clients that do not authenticate are now disconnected after 30 seconds ([#59](https://github.com/unfoldedcircle/ucd3-firmware/pull/59)).
+- Increased the maximum number of client connections from 7 to 18 ([#60](https://github.com/unfoldedcircle/ucd3-firmware/pull/60)).
+- Unified support for firmware revisions 4 and 6 ([#66](https://github.com/unfoldedcircle/ucd3-firmware/pull/66)).
 
 ## Beta Release 0.8.2 - 2026-02-14
 ### Fixed


### PR DESCRIPTION
## Release 0.10.3 - 2026-06-24
Changes since the last public release, 0.8.2.

### Fixed
- Improved overall stability and automatic cleanup of stuck client connections.
- Fixed support for IR codes with a data value of `0`, such as the digit “0” on Philips TVs using the RC6 protocol ([bug-tracker#721](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/721)).
- Improved Ethernet connection reliability ([#89](https://github.com/unfoldedcircle/ucd3-firmware/pull/89)).
- UART settings can now be changed without restarting the Dock ([#84](https://github.com/unfoldedcircle/ucd3-firmware/pull/84)).

### Added
- Added an embedded web management interface for configuring and managing the Dock from a browser ([#76](https://github.com/unfoldedcircle/ucd3-firmware/pull/76)).
- Added support for static network configuration, allowing manual IP address settings ([#81](https://github.com/unfoldedcircle/ucd3-firmware/pull/81)).
- Added RS232 support with an optional TCP serial bridge ([#72](https://github.com/unfoldedcircle/ucd3-firmware/pull/72)).
  - On current devices, RS232 mode is limited to port 2. Port 1 may send startup output that some connected RS232 devices could interpret as commands.
  - UART TTL adapters are not supported because they use different signal levels.
- Added a new log router to improve diagnostics and troubleshooting ([#77](https://github.com/unfoldedcircle/ucd3-firmware/pull/77)).
- Added support for learning and sending RAW IR commands ([#85](https://github.com/unfoldedcircle/ucd3-firmware/pull/85), [#87](https://github.com/unfoldedcircle/ucd3-firmware/pull/87)).

### Changed
- If the maximum number of client connections is reached, the least active connection is now closed automatically to allow a new connection ([#58](https://github.com/unfoldedcircle/ucd3-firmware/pull/58)).
- Clients that do not authenticate are now disconnected after 30 seconds ([#59](https://github.com/unfoldedcircle/ucd3-firmware/pull/59)).
- Increased the maximum number of client connections from 7 to 18 ([#60](https://github.com/unfoldedcircle/ucd3-firmware/pull/60)).
- Unified support for firmware revisions 4 and 6 ([#66](https://github.com/unfoldedcircle/ucd3-firmware/pull/66)).
