### PR TITLE
Fix Port 1 initialization at startup (regression from 0.10.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Fixed
+- Port 1 initialization at startup. Regression introduced in 0.10.3.
+
 ---
 
 ## Release 0.10.3 - 2026-06-24

--- a/components/external_port/external_port.cpp
+++ b/components/external_port/external_port.cpp
@@ -338,10 +338,6 @@ esp_err_t ExternalPort::setUartConfig(std::unique_ptr<UartConfig> config) {
     if (config == nullptr) {
         return ESP_ERR_INVALID_ARG;
     }
-    if (!isModeSupported(RS232)) {
-        ESP_LOGW(tag_, "Output %d does not support RS232 mode", port_);
-        return ESP_ERR_NOT_SUPPORTED;
-    }
 
     if (mode_ == RS232) {
         ESP_LOGW(tag_, "Output is already configured to RS232: new UART cfg will be applied at next init!");

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -293,10 +293,8 @@ port_map_t init_external_ports(Config *cfg, std::shared_ptr<AdcUnit> adc_unit,
             ESP_LOGW(TAG, "Invalid UART configuration for port %d: using default", i);
         }
 
-        esp_err_t ret = ports[i]->setUartConfig(std::move(cfg));
-        if (ret == ESP_OK) {
-            ret = ports[i]->init(port_mode);
-        }
+        ports[i]->setUartConfig(std::move(cfg));  // no check required, invalid uart cfg will fail the init() call below
+        esp_err_t ret = ports[i]->init(port_mode);
         if (ret != ESP_OK) {
             ESP_LOGE(TAG, "External port %d could not be initialized. Error %d", i, ret);
             uc_error_check(ESP_FAIL, i == 1 ? uc_errors::UC_ERROR_INIT_PORT1 : uc_errors::UC_ERROR_INIT_PORT2);

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -1151,7 +1151,7 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
     } else if (command == "get_port_mode") {
         code = processGetPortMode(root, responseDoc);
     } else if (command == "set_port_mode") {
-        code = processSetPortMode(root);
+        code = processSetPortMode(root, responseDoc);
     } else if (command == "get_port_trigger") {
         code = processGetPortTrigger(root, responseDoc);
     } else if (command == "set_port_trigger") {
@@ -1938,15 +1938,17 @@ void DockApi::addUartNode(uint8_t port, cJSON *responseDoc) {
     }
 }
 
-uint16_t DockApi::processSetPortMode(const cJSON *root) {
+uint16_t DockApi::processSetPortMode(const cJSON *root, cJSON *responseDoc) {
     uint8_t     port = cjson_get_int(root, "port");
     std::string mode_str = cjson_get_string(root, "mode", "");
     ExtPortMode mode = ExtPortMode_from_str(mode_str.c_str());
 
     if (port == 0 || port > EXTERNAL_PORT_COUNT || mode == ExtPortMode::PORT_MODE_MAX) {
+        cJSON_AddStringToObject(responseDoc, msgError, "Invalid port");
         return 400;
     }
     if (!ports_.contains(port)) {
+        cJSON_AddStringToObject(responseDoc, msgError, "Port not available");
         return 503;
     }
 
@@ -1958,6 +1960,7 @@ uint16_t DockApi::processSetPortMode(const cJSON *root) {
     if (mode == RS232) {
         cJSON *uart = cJSON_GetObjectItem(root, "uart");
         if (!cJSON_IsObject(uart)) {
+            cJSON_AddStringToObject(responseDoc, msgError, "uart obj missing");
             return 400;
         }
 
@@ -1968,6 +1971,7 @@ uint16_t DockApi::processSetPortMode(const cJSON *root) {
 
         auto uart_cfg = UartConfig::fromParams(baud_rate, data_bits, parity, stop_bits);
         if (uart_cfg == nullptr) {
+            cJSON_AddStringToObject(responseDoc, msgError, "Invalid uart configuration");
             return 400;
         }
         std::string uart_str = uart_cfg->toString();
@@ -1990,8 +1994,10 @@ uint16_t DockApi::processSetPortMode(const cJSON *root) {
             }
             return 200;
         case ESP_ERR_NOT_SUPPORTED:
+            cJSON_AddStringToObject(responseDoc, msgError, "mode not supported");
             return 400;
         case ESP_ERR_INVALID_STATE:
+            cJSON_AddStringToObject(responseDoc, msgError, "invalid peripheral detected");
             return 409;  // conflict: invalid peripheral detected
         case ESP_ERR_NOT_FINISHED:
             return 501;  // not yet implemented

--- a/main/ucd_api.h
+++ b/main/ucd_api.h
@@ -58,7 +58,7 @@ class DockApi {
     uint16_t processGetPortMode(const cJSON* root, cJSON* responseDoc);
     void     fillPortMode(const std::shared_ptr<ExternalPort>& extPort, cJSON* responseDoc);
     void     addUartNode(uint8_t port, cJSON* responseDoc);
-    uint16_t processSetPortMode(const cJSON* root);
+    uint16_t processSetPortMode(const cJSON* root, cJSON* responseDoc);
     uint16_t processGetPortTrigger(const cJSON* root, cJSON* responseDoc);
     uint16_t processSetPortTrigger(const cJSON* root);
 


### PR DESCRIPTION
Setting the UART configuration in the ExternalPort class may not check if the port supports RS232.
Reason: `setUartConfig` only stores the UART settings but does not apply them. The port mode checking is done in `init` (and only requiring the UART settings for RS232 mode).