### PR TITLE
refactor: disconnect all WS clients after changing the access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Changed
+- Add a token change warning in web-ui ([#96](https://github.com/unfoldedcircle/ucd3-firmware/pull/96)).
+- Disconnect all WebSocket clients after changing the access token.
+
 ---
 
 ## Release 0.10.4 - 2026-06-25

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -178,6 +178,27 @@ void schedule_restart(WebServer *web, uint16_t delay_ms, bool reset = false) {
     ESP_ERROR_CHECK(esp_timer_start_once(periodic_timer, delay_ms * 1000));
 }
 
+static void disconnect_clients(void *arg) {
+    WebServer *web = static_cast<WebServer *>(arg);
+    if (web) {
+        web->disconnectAll();
+    }
+}
+
+void schedule_disconnect_all(WebServer *web, uint16_t delay_ms) {
+    const esp_timer_create_args_t timer_args = {
+        .callback = &disconnect_clients,
+        .arg = web,
+        .dispatch_method = ESP_TIMER_TASK,
+        .name = "disconnect_all",
+        .skip_unhandled_events = false,
+    };
+
+    esp_timer_handle_t timer;
+    ESP_ERROR_CHECK(esp_timer_create(&timer_args, &timer));
+    ESP_ERROR_CHECK(esp_timer_start_once(timer, delay_ms * 1000));
+}
+
 /// @brief cJSON helper function to read an integer
 /// @param root json object
 /// @param field field name
@@ -747,6 +768,9 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
                     cJSON_AddStringToObject(responseDoc, msgError, "Token length must be 4..40");
                 } else {
                     ok = config_->setToken(token);
+                    if (ok) {
+                        schedule_disconnect_all(web, 1000);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When changing the access token, force clients to re-authenticate with the new access token.
Otherwise, the client remains connected until it disconnects and fails at the next reconnection (which can be much later).