### PR TITLE
fix: properly check token field in auth message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Fixed
+- Runtime crash for malformed authentication messages.
+
 ### Changed
 - Add a token change warning in web-ui ([#96](https://github.com/unfoldedcircle/ucd3-firmware/pull/96)).
 - Disconnect all WebSocket clients after changing the access token.

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -692,7 +692,7 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         item = cJSON_GetObjectItem(root, msgToken);
         value = cJSON_GetStringValue(item);
 
-        if (value == config_->getToken()) {
+        if (value && config_->getToken() == value) {
             // add client to authorized clients
             if (web->setAuthenticated(sockfd) == ESP_OK) {
                 if (xSemaphoreTake(unauthenticated_fds_mutex_, AUTH_MUTEX_BLOCK_TIME) != pdTRUE) {


### PR DESCRIPTION
Avoid a runtime crash if token field is not provided.