### PR TITLE
fix: reliably stop IR repeat/hold when the initiating client disconnects

### DIFF
--- a/components/infrared/service_ir.cpp
+++ b/components/infrared/service_ir.cpp
@@ -219,16 +219,39 @@ uint16_t InfraredService::send(int16_t clientId, uint32_t msgId, const std::stri
         return 400;
     }
 
+    // Safety cap on the client-requested repeat count. The `repeat` field is a uint16_t and is not
+    // range-checked on the WebSocket API, so without this a client could request a very large repeat
+    // value and trigger a runaway transmission (e.g. sending "volume up" dozens of times from a single
+    // request). Press-and-hold is unaffected: a client holds a button by repeatedly extending the
+    // active repeat with the same command (see the matching-extend branch below), not by requesting a
+    // large initial repeat count.
+    if (repeat > MAX_REPEAT) {
+        ESP_LOGW(irLog, "repeat count %u exceeds limit %lu, capping", repeat, MAX_REPEAT);
+    }
+    repeat = static_cast<uint16_t>(std::min<uint32_t>(repeat, MAX_REPEAT));
+
     bool sending = uxQueueMessagesWaiting(m_queue) > 0;
 
-    // #30 handle IR repeat if it's the same command. This is a very simple, initial implementation (ignore repeat val)
+    // #30 A request for the currently-active code extends its repeat/hold ("press-and-hold"): while the
+    // button is held the client keeps re-sending the same command. Re-arm the repeat so the send task
+    // starts another countdown on its next repeat-callback tick.
+    // Notes:
+    // - the repeat value itself is ignored on an extend.
+    // - a genuine stop (IR_REPEAT_STOP_BIT, set only by ir_stop or by the owning client
+    //   disconnecting) is intentionally NOT cleared here. A stop always takes priority in the send-task
+    //   callback, which is the safe default: if the owner asked to stop, the repeat must stop.
     if (sending && repeat > 0 && m_currentSendCode == code) {
         ESP_LOGI(irLog, "repeat req %lu", msgId);
         xEventGroupSetBits(m_eventgroup, IR_REPEAT_BIT);
         return 202;  // extended IR repeat sequence
     }
 
-    // try to save an allocation if still sending an IR code
+    // A request arrived while a different transmission is still active (different code, or repeat == 0).
+    // Only one IR transmission may be active at a time, so this request is rejected with 429. The active
+    // send is deliberately left running: a rejected request from one client must never cancel another
+    // client's in-progress repeat/hold. The active send ends on its own terms — when its owner stops
+    // extending it (the repeat counts down), on an explicit ir_stop, or when the owning client
+    // disconnects (handled in the WebSocket layer). The caller may retry shortly after.
     if (sending) {
         return 429;  // too many requests
     }

--- a/components/infrared/service_ir.cpp
+++ b/components/infrared/service_ir.cpp
@@ -435,6 +435,9 @@ void InfraredService::send_ir_f(void *param) {
         if (bits & IR_REPEAT_STOP_BIT) {
             // abort immediately
             repeat = 0;
+            if (holdTimeLimit > 0) {
+                holdTimeLimit = 1;
+            }
             ESP_LOGI(irLogSend, "stopping repeat");
         } else if (bits & IR_REPEAT_BIT) {
             // reset repeat count and start counting down again
@@ -481,8 +484,8 @@ void InfraredService::send_ir_f(void *param) {
         // pIrMsg now points to the struct IRSendMessage variable, but the item still remains on the queue.
         // This blocks the sender from queuing more messages and notify the client with a "busy error".
 
-        ESP_LOGI(irLogSend, "new command: id=%lu, format=%u, repeat=%u, mask_e=%llu, mask_s=%llu, mask_c=%llu",
-                 pIrMsg->msgId, (uint8_t)pIrMsg->format, pIrMsg->repeat, pIrMsg->pin_mask.w1ts_enable,
+        ESP_LOGI(irLogSend, "new command: id=%lu, format=%u, repeat=%u, hold=%u, mask_e=%llu, mask_s=%llu, mask_c=%llu",
+                 pIrMsg->msgId, (uint8_t)pIrMsg->format, pIrMsg->repeat, pIrMsg->hold, pIrMsg->pin_mask.w1ts_enable,
                  pIrMsg->pin_mask.w1ts, pIrMsg->pin_mask.w1tc);
 
         if (pIrMsg->hold > 0 && pIrMsg->repeat == 0) {
@@ -543,7 +546,7 @@ void InfraredService::send_ir_f(void *param) {
                         if (min_repeat > 1) {
                             data.repeat = std::min(static_cast<uint32_t>(data.repeat * min_repeat), MAX_REPEAT);
                             repeatLimit = data.repeat;
-                            ESP_LOGI(irLogSend, "repeat: req=%u, min=%d, ir=%d", pIrMsg->repeat, min_repeat,
+                            ESP_LOGD(irLogSend, "repeat: req=%u, min=%d, ir=%d", pIrMsg->repeat, min_repeat,
                                      data.repeat);
                         }
                     }

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -846,8 +846,6 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
         std::string format = cjson_get_string(root, "format", "");
         uint16_t    response = 400;
 
-        sockfdSendIR_ = -1;
-
         // make sure there are no leading or trailing spaces that could interfere with PRONTO parsing
         trim(ir_code);
 
@@ -867,9 +865,22 @@ esp_err_t DockApi::processRequest(httpd_req_t *req, int sockfd, const char *text
                                                            intTop, ext1, ext2);
             if (response == 0 || (response == 202 && (feature & API_FEATURE_FLAG_IR_REPEAT_NO_RESPONSE))) {
                 // asynchronous reply
-                if (repeat > 1) {
-                    // save client socket to stop IR repeat on WebSocket disconnect
+                //
+                // Remember which client owns a continuously-transmitting send so it can be stopped if
+                // that client disconnects (see the WS_DISCONNECTED handling). A send transmits
+                // continuously whenever `repeat > 0` OR `hold > 0`: the IR send task promotes a
+                // hold-only request (`hold > 0 && repeat == 0`) to `repeat = 1` and keeps transmitting
+                // until the hold timer expires (see InfraredService::send_ir_f). This tracking condition
+                // MUST match that definition — otherwise a press-and-hold started via the `hold`
+                // parameter would keep transmitting after its initiating client vanished.
+                if (repeat > 0 || hold > 0) {
+                    // save client socket to stop the active IR repeat/hold on WebSocket disconnect
                     sockfdSendIR_ = sockfd;
+                } else if (response == 0) {
+                    // response == 0 means a brand new transmission was queued (nothing was active before,
+                    // see InfraredService::send()), and it neither repeats nor holds: nothing is left
+                    // running to track once it completes.
+                    sockfdSendIR_ = -1;
                 }
                 cJSON_Delete(responseDoc);
                 cJSON_Delete(root);


### PR DESCRIPTION
### Problem
An active IR repeat/hold must stop the moment its initiating WebSocket client disconnects — repeating e.g. "volume up" even a few times has real-world consequences.
The `MAX_REPEAT = 20` cap in `send_ir_f` is only a secondary safety net, not the primary guarantee.

`ir_send` tracks the owning client in a single scalar `sockfdSendIR_` so the `WS_DISCONNECTED` handler can call `stopSend()`. Two defects broke that:

1. **Tracking clobbered by any client.** `sockfdSendIR_` was reset to `-1`
   unconditionally at the top of every `ir_send`, before validation. A second
   client's `ir_send` (even an invalid one) detached the tracking from a
   still-active repeat owned by a different client — the disconnect cleanup
   then saw `-1` and never stopped it. The repeat ran indefinitely with no
   client left able to `ir_stop` it.
2. **Hold not tracked.** The condition was `repeat > 1`, but the send task
   treats a send as continuously transmitting whenever `repeat > 0` **or**
   `hold > 0` (it promotes a hold-only request to `repeat = 1`). A
   press-and-hold started via the `hold` parameter set `sockfdSendIR_ = -1`,
   so a mid-hold disconnect was never stopped.

### Intended behaviour (now documented in code)
- Multiple WebSocket clients may each send commands.
- Only one IR transmission is active at a time.
- The same client extends a repeat by re-sending the same command while active.
- A second client's `ir_send` during an active send → **429**, and the active send is **left running** (a rejected request never cancels another client's repeat/hold).
- If the owning client disconnects, the repeat/hold is stopped immediately.

### Changes
- `main/ucd_api.cpp` — only touch `sockfdSendIR_` in the success branch; track
  the owner when `repeat > 0 || hold > 0` (mirrors the send task's definition of
  a continuous send).
- `components/infrared/service_ir.cpp` — reject a concurrent `ir_send` with 429
  without cancelling the active send; cap the client repeat count at
  `MAX_REPEAT` with a warning log. Explanatory comments added in both files.
- `REVIEW.md` — finding #1 updated to reflect the final fix.

### Testing
- [x] Two clients: A holds volume-up; B sends `ir_send` → B gets 429, A keeps repeating.
- [x] A starts a `hold`-based press-and-hold, then disconnects → transmission stops immediately.
- [x] A `repeat` value above 20 is capped and logs a warning.

### Notes / not addressed
`sockfdSendIR_` is shared between the request and disconnect handlers without
the mutex used for the neighbouring shared WS state. Safe while `esp_http_server` services both on one task, but inconsistent with the other locking.

---

AI Assistance Disclosure: reviewed and assisted with Claude Opus 4.8