### PR TITLE
refactor: change tick rate to 1000Hz for improving IR send timing

### DIFF
--- a/components/infrared/service_ir.cpp
+++ b/components/infrared/service_ir.cpp
@@ -385,9 +385,9 @@ void InfraredService::rebootIfMemError(int memError) {
     // Check we malloc'ed successfully.
     if (memError == 1) {  // malloc failed, so give up.
         ESP_LOGE(irLog, "FATAL: Can't allocate memory for an array for a new message! Forcing a reboot!");
-        vTaskDelay(2000 / portTICK_PERIOD_MS);  // Enough time for messages to be sent.
+        vTaskDelay(pdMS_TO_TICKS(2000));  // Enough time for messages to be sent.
         esp_restart();
-        vTaskDelay(5000 / portTICK_PERIOD_MS);  // Enough time to ensure we don't return.
+        vTaskDelay(pdMS_TO_TICKS(5000));  // Enough time to ensure we don't return.
     }
 }
 

--- a/components/preferences/config.cpp
+++ b/components/preferences/config.cpp
@@ -490,7 +490,7 @@ void Config::reset() {
 
     ESP_LOGD(m_ctx, "Resetting general done.");
 
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
 
     ESP_LOGD(m_ctx, "Resetting wifi.");
     m_preferences.begin(m_prefWifi, false);
@@ -499,7 +499,7 @@ void Config::reset() {
 
     ESP_LOGD(m_ctx, "Resetting wifi done.");
 
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
 
     ESP_LOGD(m_ctx, "Erasing flash.");
     int err;
@@ -513,7 +513,7 @@ void Config::reset() {
     // --> see workaround with a timer in the display state machine
     ESP_ERROR_CHECK_WITHOUT_ABORT(esp_event_post(UC_DOCK_EVENTS, UC_EVENT_REBOOT, NULL, 0, pdMS_TO_TICKS(500)));
 
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
 
     esp_restart();
 }

--- a/main/ucd_api.cpp
+++ b/main/ucd_api.cpp
@@ -151,7 +151,7 @@ static void restart(void *arg) {
 
     ESP_ERROR_CHECK_WITHOUT_ABORT(esp_event_post(UC_DOCK_EVENTS, UC_EVENT_REBOOT, NULL, 0, pdMS_TO_TICKS(500)));
 
-    vTaskDelay(200 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(200));
     esp_restart();
 }
 

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -8,6 +8,9 @@ CONFIG_UCD_WEB_ENABLE_CORS=y
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
 CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ=240
 
+# Use 1000Hz freertos tick for better IR accuracy with IRremoteESP8266
+CONFIG_FREERTOS_HZ=1000
+
 # disable uart0 log output in 2nd stage bootloader
 CONFIG_BOOTLOADER_LOG_LEVEL_NONE=y
 # only use usb uart


### PR DESCRIPTION
Increasing the default 100Hz tick rate to 1000Hz improves the IR signal accuracy with the IRremoteESP8266 library.
The 1000Hz tick rate allows using 1ms delay steps with vTaskDelay.

The upstream library was designed for Arduino, which forces a tick rate of 1000Hz. Using a lower tick rate increases the inter-frame delay jitter if vTaskDelay is used for longer ms delays. Usually such long delays are only used between repeat frames. Some IR protocols are robust enough to properly handle timing deviations, but not all.
Note: delays < 16ms in IRremoteESP8266 are using accurate busy loop waits.

Further change: consistently use pdMS_TO_TICKS macro with vTaskDelay.